### PR TITLE
Update homepage CTAs and expand insights content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Etterby Analytics — Jekyll Site
+# Etterby Analytics - Jekyll Site
 
 Static site built with Jekyll for GitHub Pages.
 

--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -2,7 +2,7 @@ hero:
   eyebrow: "About James Pearson"
   title: "Analytics leadership that pairs craft with commercial impact"
   description:
-    - "I operate as an embedded lead analyst for high-growth teams—shipping the infrastructure, decision science, and enablement that turn data into revenue, resilience, and trust."
+    - "I operate as an embedded lead analyst for high-growth teams - shipping the infrastructure, decision science, and enablement that turn data into revenue, resilience, and trust."
     - "Across marketplaces, SaaS platforms, and media, I have built data functions from scratch, modernised analytics programmes, and mentored analysts to operate with confidence."
 profile:
   title: "Founder & Lead Analyst"
@@ -91,4 +91,4 @@ cv:
         detail: "Team building, mentoring, agile facilitation, executive storytelling"
   education:
     title: "Education"
-    detail: "BSc (Hons) Mathematics, University of Bristol — 2009–2012 (focus on statistical analysis with first-class grades across statistics modules)."
+    detail: "BSc (Hons) Mathematics, University of Bristol - 2009-2012 (focus on statistical analysis with first-class grades across statistics modules)."

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -9,7 +9,7 @@ work:
   description: "Case studies covering fraud reduction, price optimisation, and analytics enablement across marketplaces and SaaS."
   limit: 2
   view_all:
-    label: "Browse work"
+    label: "Explore all work"
     url: "/work/"
 insights:
   title: "Latest insights"

--- a/_data/insights_page.yml
+++ b/_data/insights_page.yml
@@ -13,7 +13,7 @@ categories:
     - name: "Analytics leadership"
       detail: "Building teams, governing metrics, and embedding tools like ThoughtSpot across the org."
 newsletter:
-  title: "Stay in the loop"
-  body: "A quarterly note featuring what worked (and what didn't) while reducing fraud, lifting revenue, and rolling out BI."
-  cta_label: "Join the list"
-  cta_url: "https://etterby.com/newsletter"
+  title: "Ready to discuss your next analytics milestone?"
+  body: "Share the outcomes you are targeting and I will map the fastest path to get there."
+  cta_label: "Contact"
+  cta_url: "/contact/"

--- a/_data/services_page.yml
+++ b/_data/services_page.yml
@@ -3,7 +3,7 @@ hero:
   title: "Embedded analytics leadership for complex decisions"
   description:
     - "James Pearson works hands-on with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement you need to move faster."
-    - "Engagements are scoped around measurable outcomes—fraud reduction, revenue uplift, adoption—and pair rigorous delivery with coaching for your internal teams."
+    - "Engagements are scoped around measurable outcomes - fraud reduction, revenue uplift, adoption - and pair rigorous delivery with coaching for your internal teams."
 service_models:
   title: "Common engagement patterns"
   items:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="description" content="{{ page.description | default: site.description }}">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#0B0B0C">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="/assets/site.webmanifest">
   <link rel="apple-touch-icon" href="/assets/og-image.png">
-  <meta property="og:title" content="{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}">
+  <meta property="og:title" content="{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}">
   <meta property="og:description" content="{{ page.description | default: site.description }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">

--- a/_posts/2025-09-21-clickhouse-vs-postgres.md
+++ b/_posts/2025-09-21-clickhouse-vs-postgres.md
@@ -4,3 +4,9 @@ title: "When ClickHouse shines"
 
 Where columnar OLAP wins for event data and how to roll it out pragmatically.
 
+The decision to introduce ClickHouse at Xcelirate came after months of watching Postgres wheeze under customer events. Analysts needed multi month lookbacks to explain fraud patterns and the row store was not built for that scale. ClickHouse gave us sub second responses on the same hardware once we modelled the data around the questions product and risk teams asked every week.
+
+It is not a silver bullet though. For transactional workloads and operational updates, Postgres remains the system of record. The winning pattern has been to stream change data capture into ClickHouse, apply dbt for modelling, and keep Postgres for writes and mission critical OLTP. That mirrors how we rolled out analytics at Vita Mojo where Looker and ThoughtSpot relied on consistent semantics built on top of the warehouse.
+
+Success hinges on enablement. Engineers needed cheat sheets for materialised views, analysts required query templates, and leadership wanted clear SLAs. By pairing the migration with documentation and training, we made ClickHouse an accelerator rather than a distraction.
+

--- a/_posts/2025-09-21-from-heuristics-to-ml.md
+++ b/_posts/2025-09-21-from-heuristics-to-ml.md
@@ -4,3 +4,9 @@ title: "From heuristics to ML"
 
 Shadow evaluation, thresholds, and change management that sticks.
 
+When marketplaces asked for machine learning to replace the heuristics their operations teams had curated for years, I pushed for quiet launches first. We rebuilt the checks as Python services, ran them alongside the legacy rules, and compared every alert. That shadow period exposed blind spots without taking unnecessary risks.
+
+Only once precision and recall cleared the thresholds agreed with finance and compliance did we talk about full go live. Documentation, retraining cadences, and rollback paths were written before we made the switch. Those controls are the reason the fraud programmes I led at Xcelirate and The Stars Group hit targets without disrupting good customers.
+
+Technology is the easy part. The harder work is showing frontline teams how their expertise shaped the model and giving them avenues to override with reason. Working sessions, release notes, and a cadence for feedback help the change land. The same playbook translated to deploying experimentation platforms and pricing models across distributed Vita Mojo teams.
+

--- a/_posts/2025-09-21-outcome-first-analytics.md
+++ b/_posts/2025-09-21-outcome-first-analytics.md
@@ -4,3 +4,9 @@ title: "Outcome-first analytics"
 
 Prioritise decisions and measurable change over tooling debates. A simple playbook that aligns data work to outcomes.
 
+Every engagement starts with the same exercise I run with founders at Xcelirate and restaurant leaders at Vita Mojo. We list the commercial metrics that matter this quarter, the operational guardrails that cannot move, and the people accountable for each. That clarity stops scope creep before it starts and keeps analysts from chasing dashboard vanity projects.
+
+From there I map the smallest analytical delivery that creates feedback. At Xcelirate that meant instrumenting fraud funnels and forecasting the exposure in cash terms. At Vita Mojo it was an executive scorecard that made adoption progress visible week by week. Each increment has an owner, a baseline, and a plan to iterate if the first release only gets us part way.
+
+The last layer is enablement so teams can continue without me. Shadowing sessions, playbooks, and simple governance tables make sure context is shared and decisions are reproducible. It is the same approach that helped ThoughtSpot adoption stick with enterprise brands and kept finance, product, and operations aligned around the same numbers.
+

--- a/_work/fraud-detection-eu-classifieds.md
+++ b/_work/fraud-detection-eu-classifieds.md
@@ -9,7 +9,7 @@ duration: "16 weeks"
 position: 1
 featured: true
 summary: "Rebuilt trust & safety analytics and launched fraud models that cut abusive users from 10% to 0.6%."
-description: "James Pearson led delivery end-to-end—from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
+description: "James Pearson led delivery end-to-end - from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
 results:
   - "Reduced fraudulent users from 10% to 0.6% at 97% precision and 86% detection."
   - "Average detection window improved by 40 days with automated takedown workflows."

--- a/index.md
+++ b/index.md
@@ -8,21 +8,11 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
 <section id="hero" class="container mx-auto px-6 py-24">
   <h1 class="text-5xl md:text-6xl font-semibold leading-tight">Analytics that drive outcomes.</h1>
   <p class="mt-4 text-lg max-w-2xl">
-    I help product and operations teams ship reliable data pipelines, clear metrics, and practical ML—without drama.
+    I help product and operations teams ship reliable data pipelines, clear metrics, and practical ML - without drama.
   </p>
   <div class="mt-8 flex flex-wrap gap-4">
     <a href="/contact/" class="px-5 py-3 bg-brandblue text-white rounded-xl">Book a call</a>
     <a href="/services/" class="px-5 py-3 border rounded-xl">View services</a>
-  </div>
-</section>
-
-<section class="bg-white/5">
-  <div class="container mx-auto px-6 py-6 text-xs md:text-sm flex flex-wrap gap-x-6 gap-y-2 items-center">
-    <span class="opacity-90">UK limited company</span>
-    <span class="opacity-90">Security &amp; privacy by design</span>
-    <span class="opacity-90">dbt • Airflow • ClickHouse • Python</span>
-    <span class="opacity-90">Remote-first</span>
-    <span class="opacity-90">Clear SLAs &amp; reporting</span>
   </div>
 </section>
 
@@ -33,7 +23,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
       <h2 class="text-3xl font-semibold">{{ home_services.title }}</h2>
       <p class="mt-2 opacity-80 max-w-2xl">{{ home_services.description }}</p>
     </div>
-    <a href="{{ home_services.view_all.url }}" class="text-sm uppercase tracking-wide opacity-80 hover:opacity-100">{{ home_services.view_all.label }}</a>
+    <a href="{{ home_services.view_all.url }}" class="inline-flex px-5 py-3 bg-brandblue text-white rounded-xl text-sm uppercase tracking-wide">{{ home_services.view_all.label }}</a>
   </div>
   <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
     {% assign services = site.services | sort: 'position' %}
@@ -60,7 +50,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
       <h2 class="text-3xl font-semibold">{{ home_work.title }}</h2>
       <p class="mt-2 opacity-80 max-w-2xl">{{ home_work.description }}</p>
     </div>
-    <a href="{{ home_work.view_all.url }}" class="text-sm uppercase tracking-wide opacity-80 hover:opacity-100">{{ home_work.view_all.label }}</a>
+    <a href="{{ home_work.view_all.url }}" class="inline-flex px-5 py-3 bg-brandblue text-white rounded-xl text-sm uppercase tracking-wide">{{ home_work.view_all.label }}</a>
   </div>
   {% assign featured_work = site.work | where_exp: 'item', 'item.featured != false' | sort: 'position' %}
   {% if featured_work.size > 0 %}


### PR DESCRIPTION
## Summary
- remove the homepage accreditation tag strip and restyle the services and work links as primary CTAs
- expand the latest insight articles to reflect CV experience and replace em dashes with simple hyphens across site copy
- swap the insights newsletter panel for a direct contact call-to-action and align supporting data labels

## Testing
- bundle exec jekyll build *(fails: jekyll executable not installed in environment)*
- bundle install *(fails: rubygems.org returns HTTP 403 so dependencies cannot be installed)*