### PR TITLE
Add LinkedIn link to site header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,6 +10,7 @@
         {% for item in site.data.nav %}
           <a href="{{ item.url }}" class="hover:text-white transition">{{ item.title }}</a>
         {% endfor %}
+        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
         <a href="/contact/" class="inline-flex items-center justify-center px-4 py-2 rounded-lg border border-brandblue/60 text-white/90 hover:bg-brandblue hover:border-brandblue transition">Work together</a>
       </nav>
     </div>
@@ -19,6 +20,7 @@
       {% for item in site.data.nav %}
         <a href="{{ item.url }}" class="py-1 hover:text-white transition">{{ item.title }}</a>
       {% endfor %}
+      <a href="https://www.linkedin.com/in/james-pearson-etterby" class="py-1 hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/contact/" class="mt-2 inline-flex items-center justify-center px-4 py-2 rounded-lg bg-brandblue text-white">Work together</a>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- add a LinkedIn link to the desktop navigation alongside existing header actions
- include the same LinkedIn link in the mobile navigation to maintain consistency with the footer

## Testing
- ⚠️ `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" when fetching gems)*
