### PR TITLE
Add dashboard and tagging content across services, work, and insights

### DIFF
--- a/_data/insights_page.yml
+++ b/_data/insights_page.yml
@@ -3,15 +3,18 @@ hero:
   title: "Insights shaped by hands-on delivery"
   description:
     - "Field-tested guidance on experimentation, forecasting, and analytics leadership pulled from shipping platforms, pricing models, and enablement programmes."
+    - "Pragmatic lessons on GA4 tagging, dashboard adoption, and self-service design delivered across restaurants, retail, and SaaS."
 categories:
   title: "Topics you can explore"
   items:
+    - name: "Self-service analytics"
+      detail: "Designing dashboards, narratives, and rituals that keep teams engaged without extra analyst effort."
+    - name: "Digital tagging & instrumentation"
+      detail: "Making GA4, consent, and event design dependable so marketing and product see the same numbers."
     - name: "Experimentation"
       detail: "Designing test roadmaps, automating analysis, and communicating outcomes with confidence."
     - name: "Revenue & pricing"
       detail: "Forecasting demand, modelling elasticity, and aligning finance with product."
-    - name: "Analytics leadership"
-      detail: "Building teams, governing metrics, and embedding tools like ThoughtSpot across the org."
 newsletter:
   title: "Ready to discuss your next analytics milestone?"
   body: "Share the outcomes you are targeting and I will map the fastest path to get there."

--- a/_data/services_page.yml
+++ b/_data/services_page.yml
@@ -4,6 +4,7 @@ hero:
   description:
     - "James Pearson works hands-on with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement you need to move faster."
     - "Engagements are scoped around measurable outcomes - fraud reduction, revenue uplift, adoption - and pair rigorous delivery with coaching for your internal teams."
+    - "Recent work spans GA4 instrumentation, self-serve dashboard design, and executive storytelling for global restaurant and retail brands."
 service_models:
   title: "Common engagement patterns"
   items:

--- a/_data/work_page.yml
+++ b/_data/work_page.yml
@@ -3,6 +3,7 @@ hero:
   title: "Case studies that match analytics craft with business results"
   description:
     - "Each engagement blends data engineering, experimentation, and enablement. The focus: measurable shifts in fraud, revenue, or adoption that sustain after handover."
+    - "Highlights include GA4 tagging recoveries, franchise dashboard relaunches, and revenue experimentation embedded with client teams."
 filters:
   title: "What we deliver"
   items:

--- a/_posts/2025-09-22-designing-self-service-dashboards.md
+++ b/_posts/2025-09-22-designing-self-service-dashboards.md
@@ -1,0 +1,11 @@
+---
+title: "Designing dashboards people actually use"
+---
+
+Wireframes and hero metrics are table stakes. The dashboards that stick pair narrative, diagnostics, and ritual.
+
+While leading analytics for Subway franchisees and Vita Mojo operators we started every build by interviewing the people opening the dashboard each morning. Their questions shaped the first three tiles, the comparisons, and the alerting rules. Without that context the prettiest layout still sent users back to spreadsheets.
+
+The second ingredient is performance. ThoughtSpot, Power BI, and Hex are only self-serve if they stay sub-second and the data definitions line up with finance. That meant investing as much time in dbt models, caching, and observability as we did in colours and chart types.
+
+Finally we handed over more than a link. Every launch included release notes, loom walk-throughs, telemetry, and a playbook for how to request tweaks. Adoption is a product, not a deliverable, and treating it like one turns dashboards into decision engines.

--- a/_posts/2025-09-22-ga4-tagging-governance.md
+++ b/_posts/2025-09-22-ga4-tagging-governance.md
@@ -1,0 +1,11 @@
+---
+title: "Making GA4 tagging dependable"
+---
+
+The GA4 rush left many teams with brittle instrumentation and consent gaps. Fixing it starts with ownership.
+
+When I supported a private equity portfolio on their GA4 migration the first win was agreeing who owned each step: agencies handled creative, but measurement planning, QA, and release notes lived with the internal analytics squad. That alignment alone stopped three launch-day outages.
+
+Next came automation. We wired server-side tagging, wrote dbt tests against the export tables, and hooked up Slack alerts when payloads drifted. Manual spot checks still mattered, but the guardrails caught issues before revenue reporting went sideways.
+
+Finally we treated documentation as a product. Every change shipped with measurement diagrams, consent implications, and a rollback plan. It gave marketing the confidence to move fast without sacrificing data quality—or inviting regulators to the party.

--- a/_services/analytics-bi.md
+++ b/_services/analytics-bi.md
@@ -1,6 +1,6 @@
 ---
 title: "Analytics, BI & Enablement"
-position: 2
+position: 3
 tagline: "Semantic layers, KPI frameworks, and embedded analytics people adopt."
 summary: "Define metrics once, serve them everywhere, and enable teams with workshops, playbooks, and support."
 description: "Frameworks proven across Vita Mojo, Subway, Leon, and finance teams needing consistent reporting."

--- a/_services/digital-analytics-tagging.md
+++ b/_services/digital-analytics-tagging.md
@@ -1,0 +1,24 @@
+---
+title: "Tagging & Digital Analytics Foundations"
+position: 2
+tagline: "Instrumentation, consent, and GA4 tracking that marketing and product can trust."
+summary: "Stabilise Google Analytics, GTM, and consent journeys so every campaign and funnel report is decision-ready."
+description: "Grounded in James Pearson's work modernising Vita Mojo's restaurant analytics and advising PE-backed retail brands."
+focus:
+  - GA4 & GTM
+  - Consent Governance
+  - Event Design
+---
+
+**Where we start**
+- Audit GA4 properties, GTM containers, and consent flows against regulatory and commercial requirements
+- Map high-value journeys across web, app, and kiosk to align event naming and parameters with revenue goals
+- Prioritise fixes and net-new instrumentation with an agreed backlog, owners, and implementation plan
+
+**Outcomes**
+- Robust tagging and consent management passing data-loss and privacy reviews
+- Source-of-truth GA4 and BigQuery datasets powering campaign optimisation and product discovery
+- Playbooks that let marketing, product, and agencies launch with confidence and minimal rework
+
+**Stack**
+GA4, GTM, server-side tagging, BigQuery, Looker Studio, dbt

--- a/_services/experimentation-forecasting-applied-ml.md
+++ b/_services/experimentation-forecasting-applied-ml.md
@@ -1,6 +1,6 @@
 ---
 title: "Experimentation, Forecasting & Applied ML"
-position: 3
+position: 5
 tagline: "Practical models and test programmes tied directly to commercial metrics."
 summary: "Frame the decision, design robust experiments or models, and keep them accountable in production."
 description: "From fraud detection to revenue forecasting, every build is anchored in James Pearson's decade leading decision science."

--- a/_services/revenue-lifecycle-intelligence.md
+++ b/_services/revenue-lifecycle-intelligence.md
@@ -1,6 +1,6 @@
 ---
 title: "Revenue & Lifecycle Intelligence"
-position: 4
+position: 6
 tagline: "Pricing, retention, and forecasting programmes that influence the P&L."
 summary: "Blend predictive modelling, experimentation, and stakeholder storytelling to unlock revenue and customer lifetime value."
 description: "Battle-tested through price optimisation, lifecycle forecasts, and exec reporting delivered for Xcelirate and global gaming brands."

--- a/_services/self-service-dashboards.md
+++ b/_services/self-service-dashboards.md
@@ -1,0 +1,24 @@
+---
+title: "Self-Service Dashboards & Embedded Analytics"
+position: 4
+tagline: "Design KPI stories and workflows that teams return to every day."
+summary: "Craft ThoughtSpot, Power BI, and Hex experiences that answer follow-up questions and unlock adoption."
+description: "Built from James Pearson's delivery for Subway franchisees, Vita Mojo operators, and private equity portfolio reviews."
+focus:
+  - Dashboard Design
+  - Embedded Workflows
+  - Adoption
+---
+
+**Where we start**
+- Review existing dashboards and stakeholder interviews to understand the questions that matter most
+- Prioritise personas and decision moments, then wireframe stories that surface the right metrics and diagnostics
+- Pair design with data modelling and performance tuning so dashboards stay fast and reliable in production
+
+**Outcomes**
+- Executive and operator dashboards that drive weekly and daily rituals across teams
+- Embedded analytics in portals and products with clear ownership, release plans, and usage telemetry
+- Enablement assets that teach teams how to self-serve, explore, and request enhancements effectively
+
+**Stack**
+ThoughtSpot, Power BI, Hex, Looker, Superset, Mode

--- a/_work/ga4-tagging-retail-portfolio.md
+++ b/_work/ga4-tagging-retail-portfolio.md
@@ -1,0 +1,30 @@
+---
+title: "GA4 tagging overhaul for omnichannel retail"
+client: "Private Equity Portfolio"
+industry: "Retail & E-commerce"
+services:
+  - Tagging & Digital Analytics Foundations
+  - Data Platforms & Reliability
+duration: "8 weeks"
+position: 4
+featured: false
+summary: "Stabilised Google Analytics, consent flows, and campaign attribution across five portfolio brands."
+description: "James Pearson led the tagging migration and governance playbook so marketing and product teams could rely on GA4 and BigQuery for decision-making."
+results:
+  - "Unified GTM containers with consent-aware deployment and automated QA."
+  - "GA4 to BigQuery export powering merchandising and acquisition dashboards within four weeks."
+  - "Runbooks that let agencies launch campaigns without breaking instrumentation."
+---
+
+### Problem
+Disparate GA4 setups, consent tools, and agencies created data loss and conflicting revenue numbers for leadership.
+
+### Solution
+- Conducted a multi-brand audit covering GA4 schemas, ecommerce events, and CMP integrations
+- Rebuilt measurement plans, implemented enhanced ecommerce tagging, and automated validation with server-side tests
+- Partnered with marketing to embed governance rituals and roll out executive-ready dashboards
+
+### Outcome
+- Trustworthy acquisition and merchandising reporting within one source of truth
+- Faster go-to-market for seasonal campaigns backed by pre-launch QA checklists
+- Internal teams confident managing instrumentation without constant contractor support

--- a/_work/metrics-modernisation-b2b-saas.md
+++ b/_work/metrics-modernisation-b2b-saas.md
@@ -6,7 +6,7 @@ services:
   - Analytics, BI & Enablement
   - Data Platforms & Reliability
 duration: "12 weeks"
-position: 2
+position: 3
 featured: true
 summary: "Delivered a governed metrics layer and ThoughtSpot rollout that aligned revenue and product teams."
 description: "James Pearson led the KPI framework, modelling, and enablement that standardised reporting for internal teams and enterprise restaurant brands."

--- a/_work/price-optimisation-xcelirate.md
+++ b/_work/price-optimisation-xcelirate.md
@@ -6,7 +6,7 @@ services:
   - Revenue & Lifecycle Intelligence
   - Experimentation, Forecasting & Applied ML
 duration: "10 weeks"
-position: 3
+position: 5
 featured: false
 summary: "Delivered dynamic pricing and forecasting models that lifted daily revenue by 10%."
 description: "James Pearson combined experimentation, predictive modelling, and stakeholder enablement to embed pricing science into commercial planning."

--- a/_work/self-service-dashboards-restaurant-group.md
+++ b/_work/self-service-dashboards-restaurant-group.md
@@ -1,0 +1,30 @@
+---
+title: "Self-service analytics for global restaurant operators"
+client: "Subway & Vita Mojo"
+industry: "Restaurants & Hospitality"
+services:
+  - Self-Service Dashboards & Embedded Analytics
+  - Analytics, BI & Enablement
+duration: "14 weeks"
+position: 2
+featured: true
+summary: "Delivered franchise performance dashboards and enablement that unlocked daily self-serve usage."
+description: "James Pearson partnered with Subway International and Vita Mojo to redesign analytics for franchise owners and operator teams, pairing KPI storytelling with technical delivery."
+results:
+  - "Franchisee dashboards adopted across 20+ markets with role-based navigation and automated commentary."
+  - "Daily active users tripled as operators relied on guided analyses for staffing, menu, and promotions."
+  - "Embedded analytics in the Vita Mojo portal with governance, release notes, and telemetry to steer iterations."
+---
+
+### Problem
+Operators were overwhelmed by ad-hoc spreadsheets and slow dashboards, making it difficult to spot underperforming stores and campaign ROI.
+
+### Solution
+- Interviewed franchisees, marketing, and operations leaders to map critical decisions and reporting rituals
+- Rebuilt KPI definitions in dbt and tuned ThoughtSpot/Power BI models for sub-second exploration
+- Designed story-driven dashboards with usage telemetry, certification workflows, and enablement programmes
+
+### Outcome
+- Weekly franchise reviews anchored on consistent dashboards and alerts
+- Reduced analyst support tickets as owners self-served diagnostics and exported recommendations
+- Ongoing roadmap owned by internal teams with James advising on quarterly enhancements


### PR DESCRIPTION
## Summary
- add dedicated services for GA4 tagging foundations and self-service dashboards while reordering existing offerings
- expand work portfolio with tagging and dashboard case studies plus refreshed hero copy aligning with recent engagements
- publish new insights articles highlighting dependable GA4 instrumentation and high-adoption dashboard design

## Testing
- bundle exec jekyll build *(fails: jekyll not installed in environment)*
- bundle install *(fails: unable to download gems due to 403 from rubygems.org)*
