### PR TITLE
Remove telephone number and revert to remote address

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,6 @@ company:
   legal_name: "Etterby Analytics Ltd"
   url: "https://etterby.com"
   email: "hello@etterby.com"
-  telephone: "+44 20 1234 5678"
   description: "Independent analytics consultancy led by James Pearson delivering data platforms, experimentation, and forecasting."
   logo: "/assets/og-image.png"
   same_as:


### PR DESCRIPTION
## Summary
- remove the company telephone entry from the configuration
- restore the company address fields to the remote-first details
