### PR TITLE
Clarify UK-first Carlisle messaging

### DIFF
--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -2,8 +2,8 @@ hero:
   eyebrow: "About James Pearson"
   title: "Analytics leadership that pairs craft with commercial impact"
   description:
-    - "I operate as an embedded lead analyst for high-growth teams - shipping the infrastructure, decision science, and enablement that turn data into revenue, resilience, and trust."
-    - "Across marketplaces, SaaS platforms, and media, I have built data functions from scratch, modernised analytics programmes, and mentored analysts to operate with confidence."
+    - "Based in Carlisle, I operate as an embedded lead analyst for high-growth teams - shipping the infrastructure, decision science, and enablement that turn data into revenue, resilience, and trust across the UK and beyond."
+    - "Across Cumbria organisations, UK scale-ups, and selected global marketplaces, SaaS platforms, and media, I have built data functions from scratch, modernised analytics programmes, and mentored analysts to operate with confidence."
 profile:
   title: "Founder & Lead Analyst"
   name: "James Pearson"

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -1,12 +1,12 @@
 services:
   title: "Services"
-  description: "Engagements led by James Pearson to modernise data platforms, run experimentation programmes, and ship predictive models."
+  description: "Engagements led from Carlisle by James Pearson to modernise data platforms, run experimentation programmes, and ship predictive models for teams across Cumbria, the wider UK, and select global partners."
   view_all:
     label: "Explore all services"
     url: "/services/"
 work:
   title: "Selected work"
-  description: "Case studies covering fraud reduction, price optimisation, and analytics enablement across marketplaces and SaaS."
+  description: "Case studies covering fraud reduction, price optimisation, and analytics enablement for organisations across Cumbria, UK scale-ups, and select global marketplaces."
   limit: 2
   view_all:
     label: "Explore all work"

--- a/_data/services_page.yml
+++ b/_data/services_page.yml
@@ -2,8 +2,8 @@ hero:
   eyebrow: "How we help"
   title: "Embedded analytics leadership for complex decisions"
   description:
-    - "James Pearson works hands-on with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement you need to move faster."
-    - "Engagements are scoped around measurable outcomes - fraud reduction, revenue uplift, adoption - and pair rigorous delivery with coaching for your internal teams."
+    - "James Pearson works hands-on from Carlisle with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement UK-first companies need to move faster."
+    - "On-site sessions across Cumbria pair with remote collaboration that prioritises UK teams while remaining open to select global partners, with engagements scoped around measurable outcomes - fraud reduction, revenue uplift, adoption - and coaching for your internal teams."
     - "Recent work spans GA4 instrumentation, self-serve dashboard design, and executive storytelling for global restaurant and retail brands."
 service_models:
   title: "Common engagement patterns"

--- a/contact/index.md
+++ b/contact/index.md
@@ -7,7 +7,7 @@ description: "Start a conversation with James Pearson about analytics, experimen
 {% capture contact_intro %}
   <div class="max-w-2xl space-y-3">
     <h1 class="text-3xl md:text-4xl font-semibold">Contact</h1>
-    <p class="opacity-90 text-sm">Usually replies within 24h. UK/EU friendly.</p>
+    <p class="opacity-90 text-sm">Carlisle-based sessions are available across Cumbria, with remote support prioritising UK teams while staying open to select global partners.</p>
   </div>
 {% endcapture %}
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
   <div class="space-y-8">
     <h1 class="text-5xl md:text-6xl font-semibold leading-tight">Analytics that drive outcomes.</h1>
     <p class="text-lg max-w-2xl">
-      I help product and operations teams ship reliable data pipelines, clear metrics, and practical ML - without drama.
+      I run a Carlisle analytics consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
     <div class="flex flex-wrap gap-4">
       <a href="/contact/" class="px-5 py-3 bg-brandblue text-white rounded-xl">Book a call</a>


### PR DESCRIPTION
## Summary
- Emphasise Carlisle roots while signalling support for teams across Cumbria, the wider UK, and select global partners on the homepage and key data-driven sections.
- Refresh the contact introduction to remove office hours and highlight UK-priority availability with flexibility for global engagements.
- Update about and services copy to reinforce the UK-first positioning alongside openness to international partners.

## Testing
- Not run (not requested)