### PR TITLE
Fix Contact page front matter rendering

### DIFF
--- a/contact/index.md
+++ b/contact/index.md
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: "Contact"


### PR DESCRIPTION
## Summary
- remove the leading blank line on the Contact page so its front matter is parsed
- ensure the page metadata drives the browser tab title and hides the raw front matter text

## Testing
- no automated tests were run (not applicable)