### PR TITLE
Add homepage hero stat strip with case study highlights

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,20 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
     <p class="text-lg max-w-2xl">
       I run a Carlisle analytics consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
+    <div class="flex flex-wrap gap-3 text-sm md:text-base text-white/80">
+      <div class="px-4 py-2 rounded-xl border border-white/10 bg-white/5">
+        <span class="block font-semibold text-white">Fraud cut 10% → 0.6%</span>
+        <span class="block text-xs md:text-sm text-white/70">Marketplace (EU) trust &amp; safety</span>
+      </div>
+      <div class="px-4 py-2 rounded-xl border border-white/10 bg-white/5">
+        <span class="block font-semibold text-white">+10% daily revenue uplift</span>
+        <span class="block text-xs md:text-sm text-white/70">Xcelirate pricing science</span>
+      </div>
+      <div class="px-4 py-2 rounded-xl border border-white/10 bg-white/5">
+        <span class="block font-semibold text-white">Self-serve usage tripled</span>
+        <span class="block text-xs md:text-sm text-white/70">Series C SaaS metrics layer</span>
+      </div>
+    </div>
     <div class="flex flex-wrap gap-4">
       <a href="/contact/" class="px-5 py-3 bg-brandblue text-white rounded-xl">Book a call</a>
       <a href="/services/" class="px-5 py-3 border border-white/30 rounded-xl">View services</a>


### PR DESCRIPTION
## Summary
- add a stat strip beneath the hero intro copy to surface case study outcomes
- style the stats with existing flex and border utilities to align with the hero visuals

## Testing
- bundle install *(fails: Bundler cannot fetch gems due to 403 Forbidden)*