### PR TITLE
Add global light and dark theme toggle

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,25 +1,91 @@
-<footer class="border-t border-brandblue/30 bg-gradient-to-r from-brandblack via-brandblue/20 to-brandblack">
-  <div class="container mx-auto px-6 py-12 text-sm text-white/70 flex flex-wrap items-center gap-x-6 gap-y-3">
-    <span class="uppercase tracking-[0.2em] text-xs text-white/50">Etterby</span>
-    <span class="h-3 w-px bg-white/20"></span>
+<footer class="border-t border-brandblue/20 bg-gradient-to-r from-white via-brandblue/10 to-white dark:border-brandblue/30 dark:from-brandblack dark:via-brandblue/20 dark:to-brandblack transition-colors">
+  <div class="container mx-auto px-6 py-12 text-sm text-brandblack/70 dark:text-white/70 flex flex-wrap items-center gap-x-6 gap-y-3">
+    <span class="uppercase tracking-[0.2em] text-xs text-brandblack/50 dark:text-white/50">Etterby</span>
+    <span class="h-3 w-px bg-brandblack/20 dark:bg-white/20"></span>
     <span>© {{ site.time | date: "%Y" }} Etterby Analytics Ltd</span>
     <span>·</span>
-    <a href="/privacy/" class="hover:text-white transition">Privacy</a>
+    <a href="/privacy/" class="hover:text-brandblack dark:hover:text-white transition">Privacy</a>
     <span>·</span>
-    <a href="/terms/" class="hover:text-white transition">Terms</a>
+    <a href="/terms/" class="hover:text-brandblack dark:hover:text-white transition">Terms</a>
     <span>·</span>
-    <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
-    <span class="md:ml-auto text-white/60">Analytics leadership since 2012</span>
+    <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+    <span class="md:ml-auto text-brandblack/60 dark:text-white/60">Analytics leadership since 2012</span>
   </div>
 </footer>
 <script>
-  const navToggle = document.getElementById('navToggle');
-  const mobileNav = document.getElementById('mobileNav');
-  if (navToggle && mobileNav) {
-    navToggle.addEventListener('click', () => {
-      mobileNav.classList.toggle('hidden');
-      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-      navToggle.setAttribute('aria-expanded', (!expanded).toString());
-    });
-  }
+  (function() {
+    const storageKey = 'preferred-theme';
+    const root = document.documentElement;
+    const meta = document.getElementById('theme-color-meta');
+    const navToggle = document.getElementById('navToggle');
+    const mobileNav = document.getElementById('mobileNav');
+    const themeButtons = document.querySelectorAll('[data-theme-toggle]');
+
+    const applyTheme = (mode) => {
+      const isDark = mode === 'dark';
+      root.classList.toggle('dark', isDark);
+      root.dataset.theme = isDark ? 'dark' : 'light';
+      if (meta) {
+        meta.setAttribute('content', isDark ? '#0B0B0C' : '#F6F7F9');
+      }
+      if (themeButtons.length) {
+        themeButtons.forEach((button) => {
+          const label = button.querySelector('[data-theme-toggle-label]');
+          if (label) {
+            label.textContent = isDark ? 'Light mode' : 'Dark mode';
+          }
+          button.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        });
+      }
+    };
+
+    const getStoredTheme = () => {
+      try {
+        return localStorage.getItem(storageKey);
+      } catch (error) {
+        return null;
+      }
+    };
+
+    const storeTheme = (mode) => {
+      try {
+        localStorage.setItem(storageKey, mode);
+      } catch (error) {
+        /* noop */
+      }
+    };
+
+    const currentPreference = getStoredTheme();
+    if (currentPreference) {
+      applyTheme(currentPreference);
+    } else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      applyTheme(prefersDark.matches ? 'dark' : 'light');
+      prefersDark.addEventListener('change', (event) => {
+        const stored = getStoredTheme();
+        if (!stored) {
+          applyTheme(event.matches ? 'dark' : 'light');
+        }
+      });
+    }
+
+    if (themeButtons.length) {
+      themeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const isDark = root.classList.contains('dark');
+          const next = isDark ? 'light' : 'dark';
+          applyTheme(next);
+          storeTheme(next);
+        });
+      });
+    }
+
+    if (navToggle && mobileNav) {
+      navToggle.addEventListener('click', () => {
+        mobileNav.classList.toggle('hidden');
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        navToggle.setAttribute('aria-expanded', (!expanded).toString());
+      });
+    }
+  })();
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,26 +1,34 @@
 <header class="sticky top-0 z-50">
-  <div class="border-b border-white/10 bg-brandblack/90 backdrop-blur-lg">
+  <div class="border-b border-brandblack/10 bg-white/90 dark:border-white/10 dark:bg-brandblack/90 backdrop-blur-lg transition-colors">
     <div class="container mx-auto px-6 py-5 flex items-center justify-between gap-6">
       <a href="/" class="flex items-center gap-3 group">
         <img src="/assets/logo-mark.svg" alt="Etterby logo mark" class="w-8 h-8 drop-shadow-[0_6px_16px_rgba(30,95,255,0.45)] group-hover:scale-105 transition-transform">
-        <span class="font-semibold tracking-tight text-lg text-white/90 group-hover:text-white transition">Etterby <span class="text-brandblue">Analytics</span></span>
+        <span class="font-semibold tracking-tight text-lg text-brandblack/90 dark:text-white/90 group-hover:text-brandblack dark:group-hover:text-white transition">Etterby <span class="text-brandblue">Analytics</span></span>
       </a>
-      <button id="navToggle" class="md:hidden flex items-center gap-2 border border-white/20 rounded-lg px-3 py-2 text-sm text-white/80" aria-expanded="false" aria-controls="mobileNav">Menu</button>
-      <nav id="mainNav" class="hidden md:flex items-center gap-6 text-sm text-white/70">
+      <button id="navToggle" class="md:hidden flex items-center gap-2 border border-brandblack/20 dark:border-white/20 rounded-lg px-3 py-2 text-sm text-brandblack/80 dark:text-white/80 transition" aria-expanded="false" aria-controls="mobileNav">Menu</button>
+      <nav id="mainNav" class="hidden md:flex items-center gap-6 text-sm text-brandblack/70 dark:text-white/70">
         {% for item in site.data.nav %}
-          <a href="{{ item.url }}" class="hover:text-white transition">{{ item.title }}</a>
+          <a href="{{ item.url }}" class="hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
         {% endfor %}
-        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
-        <a href="/contact/" class="inline-flex items-center justify-center px-4 py-2 rounded-lg border border-brandblue/60 text-white/90 hover:bg-brandblue hover:border-brandblue transition">Work together</a>
+        <button type="button" class="hidden md:inline-flex items-center gap-2 rounded-lg border border-brandblack/20 dark:border-white/20 px-4 py-2 text-sm font-medium text-brandblack/80 dark:text-white/80 transition hover:border-brandblue/60 hover:text-brandblue dark:hover:text-brandblue" data-theme-toggle>
+          <span class="inline-flex h-2 w-2 rounded-full bg-brandblack dark:bg-white"></span>
+          <span data-theme-toggle-label>Dark mode</span>
+        </button>
+        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="/contact/" class="inline-flex items-center justify-center px-4 py-2 rounded-lg border border-brandblue/60 text-brandblack dark:text-white hover:bg-brandblue hover:border-brandblue hover:text-white transition">Work together</a>
       </nav>
     </div>
   </div>
-  <nav id="mobileNav" class="md:hidden hidden border-b border-white/10 bg-brandblack/95">
-    <div class="container mx-auto px-6 py-4 flex flex-col gap-3 text-sm text-white/80">
+  <nav id="mobileNav" class="md:hidden hidden border-b border-brandblack/10 bg-white/95 dark:border-white/10 dark:bg-brandblack/95">
+    <div class="container mx-auto px-6 py-4 flex flex-col gap-3 text-sm text-brandblack/80 dark:text-white/80">
       {% for item in site.data.nav %}
-        <a href="{{ item.url }}" class="py-1 hover:text-white transition">{{ item.title }}</a>
+        <a href="{{ item.url }}" class="py-1 hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
       {% endfor %}
-      <a href="https://www.linkedin.com/in/james-pearson-etterby" class="py-1 hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+      <button type="button" class="mt-2 inline-flex items-center justify-center gap-2 rounded-lg border border-brandblack/15 dark:border-white/20 px-4 py-2 text-sm font-medium text-brandblack/80 dark:text-white/80 transition hover:border-brandblue/60 hover:text-brandblue dark:hover:text-brandblue" data-theme-toggle>
+        <span class="inline-flex h-2 w-2 rounded-full bg-brandblack dark:bg-white"></span>
+        <span data-theme-toggle-label>Dark mode</span>
+      </button>
+      <a href="https://www.linkedin.com/in/james-pearson-etterby" class="py-1 hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/contact/" class="mt-2 inline-flex items-center justify-center px-4 py-2 rounded-lg bg-brandblue text-white">Work together</a>
     </div>
   </nav>

--- a/_includes/panel.html
+++ b/_includes/panel.html
@@ -3,13 +3,13 @@
 {% assign base = 'rounded-2xl border ' | append: padding %}
 {% case tone %}
   {% when 'frost' %}
-    {% assign classes = base | append: ' border-white/10 bg-white/5 shadow-lg shadow-black/30 backdrop-blur-sm' %}
+    {% assign classes = base | append: ' border-brandblack/10 bg-brandblack/5 shadow-lg shadow-brandblack/20 dark:border-white/10 dark:bg-white/5 dark:shadow-black/30 backdrop-blur-sm' %}
   {% when 'ink' %}
-    {% assign classes = base | append: ' border-white/10 bg-brandblack/70 shadow-lg shadow-black/50' %}
+    {% assign classes = base | append: ' border-brandblack/10 bg-white shadow-lg shadow-brandblack/10 dark:border-white/10 dark:bg-brandblack/70 dark:shadow-black/50' %}
   {% when 'outline' %}
-    {% assign classes = base | append: ' border-white/20 bg-transparent' %}
+    {% assign classes = base | append: ' border-brandblack/20 bg-transparent dark:border-white/20' %}
   {% when 'glow' %}
-    {% assign classes = base | append: ' border-brandblue/30 bg-brandblue/10 shadow-[0_20px_45px_rgba(30,95,255,0.22)]' %}
+    {% assign classes = base | append: ' border-brandblue/20 bg-brandblue/10 shadow-[0_20px_45px_rgba(30,95,255,0.12)] dark:border-brandblue/30 dark:bg-brandblue/10 dark:shadow-[0_20px_45px_rgba(30,95,255,0.22)]' %}
   {% when 'solid' %}
     {% assign classes = base | append: ' border-brandblue/60 bg-brandblue text-white' %}
   {% else %}

--- a/_includes/section.html
+++ b/_includes/section.html
@@ -6,14 +6,14 @@
   {% when 'plain' %}
     {% assign outer_classes = outer_classes %}
   {% when 'frost' %}
-    {% assign outer_classes = outer_classes | append: ' bg-white/5 border-y border-white/5' %}
+    {% assign outer_classes = outer_classes | append: ' bg-brandblack/5 border-y border-brandblack/10 dark:bg-white/5 dark:border-white/5' %}
   {% when 'ink' %}
-    {% assign outer_classes = outer_classes | append: ' bg-brandblack/80 border-y border-white/10' %}
+    {% assign outer_classes = outer_classes | append: ' bg-white border-y border-brandblack/10 dark:bg-brandblack/80 dark:border-white/10' %}
   {% when 'blue' %}
-    {% assign outer_classes = outer_classes | append: ' bg-brandblue/10 border-y border-brandblue/20' %}
+    {% assign outer_classes = outer_classes | append: ' bg-brandblue/5 border-y border-brandblue/20 dark:bg-brandblue/10' %}
   {% when 'glow' %}
     {% assign outer_classes = outer_classes | append: ' overflow-hidden' %}
-    {% assign overlay = 'bg-gradient-to-br from-brandblue/15 via-transparent to-white/10' %}
+    {% assign overlay = 'bg-gradient-to-br from-brandblue/15 via-transparent to-brandblack/10 dark:to-white/10' %}
   {% else %}
     {% assign outer_classes = outer_classes %}
 {% endcase %}

--- a/_layouts/case.html
+++ b/_layouts/case.html
@@ -18,7 +18,7 @@ layout: default
 {% capture case_body %}
   <div class="grid md:grid-cols-[2fr,1fr] gap-8 items-start">
     {% capture narrative_panel %}
-      <div class="prose prose-invert max-w-none space-y-6">
+      <div class="prose prose-neutral dark:prose-invert max-w-none space-y-6">
         {{ content }}
       </div>
     {% endcapture %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="description" content="{{ page.description | default: site.description }}">
   <meta name="robots" content="index,follow">
-  <meta name="theme-color" content="#0B0B0C">
+  <meta name="theme-color" content="#F6F7F9" id="theme-color-meta">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="/assets/site.webmanifest">
   <link rel="apple-touch-icon" href="/assets/og-image.png">
@@ -42,9 +42,36 @@
       }
     }
   </script>
+  <script>
+    (function() {
+      const storageKey = 'preferred-theme';
+      const root = document.documentElement;
+      const meta = document.getElementById('theme-color-meta');
+
+      const getStoredTheme = () => {
+        try {
+          return localStorage.getItem(storageKey);
+        } catch (error) {
+          return null;
+        }
+      };
+
+      const stored = getStoredTheme();
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const shouldUseDark = stored === 'dark' || (stored === null && prefersDark);
+
+      root.classList.toggle('dark', shouldUseDark);
+      root.dataset.theme = shouldUseDark ? 'dark' : 'light';
+
+      if (meta) {
+        meta.setAttribute('content', shouldUseDark ? '#0B0B0C' : '#F6F7F9');
+      }
+    })();
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
+      darkMode: 'class',
       theme: { extend: { colors: {
         brandblack: "#0B0B0C",
         brandoff: "#F6F7F9",
@@ -54,12 +81,13 @@
     }
   </script>
   <style>
-    :root{ --black:#0B0B0C; --off:#F6F7F9; --blue:#1E5FFF; --yellow:#FFC300; }
-    html{ scroll-behavior:smooth; }
+    :root{ --black:#0B0B0C; --off:#F6F7F9; --blue:#1E5FFF; --yellow:#FFC300; color-scheme: light; }
+    :root[data-theme="dark"]{ color-scheme: dark; }
+    html{ scroll-behavior:smooth; background-color: var(--off); }
     .container{ max-width:1120px; }
   </style>
 </head>
-<body class="bg-brandblack text-brandoff antialiased">
+<body class="bg-brandoff text-brandblack dark:bg-brandblack dark:text-brandoff antialiased transition-colors duration-300">
   {% include header.html %}
   <main class="min-h-[50vh]">{{ content }}</main>
   {% include footer.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,35 +3,35 @@ layout: default
 ---
 {% assign intro_text = page.description | default: page.subtitle | default: page.excerpt | strip_html | replace: "\n", " " | strip %}
 {% capture post_hero %}
-  <a href="/insights/" class="inline-flex items-center text-sm text-white/70 hover:text-white transition">
+  <a href="/insights/" class="inline-flex items-center text-sm text-brandblack/70 dark:text-white/70 hover:text-brandblack dark:hover:text-white transition">
     <span aria-hidden="true" class="mr-2">←</span> Back to insights
   </a>
   <div class="mt-8 max-w-3xl space-y-4">
-    <p class="text-xs uppercase tracking-[0.3em] text-white/60">{{ page.hero_label | default: "Insight" }}</p>
+    <p class="text-xs uppercase tracking-[0.3em] text-brandblack/60 dark:text-white/60">{{ page.hero_label | default: "Insight" }}</p>
     <h1 class="text-3xl md:text-5xl font-semibold leading-tight">{{ page.title }}</h1>
     {% if intro_text %}
-      <p class="text-base md:text-lg text-white/80">{{ intro_text | strip_newlines }}</p>
+      <p class="text-base md:text-lg text-brandblack/80 dark:text-white/80">{{ intro_text | strip_newlines }}</p>
     {% endif %}
-    <dl class="flex flex-wrap gap-6 text-sm text-white/60 pt-2">
+    <dl class="flex flex-wrap gap-6 text-sm text-brandblack/60 dark:text-white/60 pt-2">
       <div class="flex items-center gap-2">
         <dt class="uppercase tracking-wide">Published</dt>
-        <dd class="text-white/80">{{ page.date | date: "%d %B %Y" }}</dd>
+        <dd class="text-brandblack/80 dark:text-white/80">{{ page.date | date: "%d %B %Y" }}</dd>
       </div>
       {% if page.tags %}
         <div class="flex items-center gap-2">
           <dt class="uppercase tracking-wide">Topics</dt>
-          <dd class="text-white/80">{{ page.tags | join: ", " }}</dd>
+          <dd class="text-brandblack/80 dark:text-white/80">{{ page.tags | join: ", " }}</dd>
         </div>
       {% endif %}
     </dl>
   </div>
 {% endcapture %}
-{% include section.html tone="glow" padding="py-20" class="border-b border-white/10" content=post_hero %}
+{% include section.html tone="glow" padding="py-20" class="border-b border-brandblack/10 dark:border-white/10" content=post_hero %}
 
 {% capture post_body %}
   <div class="grid lg:grid-cols-[2fr,1fr] gap-12">
     {% capture article_panel %}
-      <article class="prose prose-invert prose-headings:font-semibold prose-a:text-brandblue max-w-none space-y-6">
+      <article class="prose prose-neutral dark:prose-invert prose-headings:font-semibold prose-a:text-brandblue max-w-none space-y-6">
         {{ content }}
       </article>
     {% endcapture %}
@@ -42,7 +42,7 @@ layout: default
         {% capture tldr_panel %}
           <div class="space-y-3">
             <h2 class="text-lg font-semibold">TLDR</h2>
-            <p class="text-sm text-white/70 leading-relaxed">{{ intro_text }}</p>
+            <p class="text-sm text-brandblack/70 dark:text-white/70 leading-relaxed">{{ intro_text }}</p>
           </div>
         {% endcapture %}
         {% include panel.html tone="frost" class="space-y-3" content=tldr_panel %}
@@ -51,7 +51,7 @@ layout: default
       {% capture challenge_panel %}
         <div class="space-y-3">
           <h2 class="text-lg font-semibold">Talk through your own challenge</h2>
-          <p class="text-sm text-white/70">Share the context behind your data and analytics goals and we'll map the fastest path to value.</p>
+          <p class="text-sm text-brandblack/70 dark:text-white/70">Share the context behind your data and analytics goals and we'll map the fastest path to value.</p>
           <a href="/contact/" class="inline-flex items-center justify-center px-5 py-3 bg-brandblue text-white rounded-xl text-sm font-medium hover:bg-brandblue/80 transition">Book a call</a>
         </div>
       {% endcapture %}
@@ -66,8 +66,8 @@ layout: default
               {% for post in other_posts limit: 3 %}
                 <li>
                   <a href="{{ post.url }}" class="block group">
-                    <span class="text-white/80 group-hover:text-white transition">{{ post.title }}</span>
-                    <span class="block text-white/50 text-xs mt-1">{{ post.date | date: "%d %b %Y" }}</span>
+                    <span class="text-brandblack/80 dark:text-white/80 group-hover:text-brandblue dark:group-hover:text-white transition">{{ post.title }}</span>
+                    <span class="block text-brandblack/50 dark:text-white/50 text-xs mt-1">{{ post.date | date: "%d %b %Y" }}</span>
                   </a>
                 </li>
               {% endfor %}

--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -16,7 +16,7 @@ layout: default
   <div class="grid md:grid-cols-[2fr,1fr] gap-8 items-start">
     {% capture article_panel %}
       <div class="space-y-6">
-        <div class="prose prose-invert max-w-none">
+        <div class="prose prose-neutral dark:prose-invert max-w-none">
           {{ content }}
         </div>
       </div>

--- a/about/index.md
+++ b/about/index.md
@@ -21,7 +21,7 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
       {% capture profile_panel %}
         <div class="space-y-3">
           <h2 class="text-2xl font-semibold">{{ page_content.profile.title }}</h2>
-          <p class="text-sm uppercase tracking-wide text-white/70">{{ page_content.profile.name }}</p>
+          <p class="text-sm uppercase tracking-wide text-brandblack/70 dark:text-white/70">{{ page_content.profile.name }}</p>
           <ul class="space-y-3 text-sm opacity-90">
             {% for item in page_content.profile.bio %}
               <li>• {{ item }}</li>
@@ -66,7 +66,7 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
       {% capture contact_panel %}
         <div class="space-y-3 text-center">
           <h2 class="text-lg font-semibold">Ready to collaborate?</h2>
-          <p class="text-sm text-white/70">Discuss your analytics roadmap and the momentum we can unlock.</p>
+          <p class="text-sm text-brandblack/70 dark:text-white/70">Discuss your analytics roadmap and the momentum we can unlock.</p>
           <a href="{{ page_content.contact_cta.url }}" class="inline-flex justify-center px-5 py-3 bg-brandblue text-white rounded-xl">{{ page_content.contact_cta.label }}</a>
         </div>
       {% endcapture %}
@@ -82,7 +82,7 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
       <h2 class="text-2xl font-semibold">{{ page_content.cv.title }}</h2>
       <p class="opacity-80">{{ page_content.cv.intro }}</p>
     </div>
-    <a href="{{ page_content.cv.download.url }}" class="inline-flex items-center justify-center px-5 py-3 border border-white/30 rounded-xl text-sm uppercase tracking-wide">{{ page_content.cv.download.label }}</a>
+    <a href="{{ page_content.cv.download.url }}" class="inline-flex items-center justify-center px-5 py-3 border border-brandblack/30 dark:border-white/30 rounded-xl text-sm uppercase tracking-wide">{{ page_content.cv.download.label }}</a>
   </div>
 {% endcapture %}
 
@@ -127,7 +127,7 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
         <ul class="space-y-3 text-sm opacity-90">
           {% for skill in page_content.cv.skills.categories %}
             <li>
-              <span class="block font-semibold text-white">{{ skill.name }}</span>
+              <span class="block font-semibold text-brandblack dark:text-white">{{ skill.name }}</span>
               <span>{{ skill.detail }}</span>
             </li>
           {% endfor %}

--- a/contact/index.md
+++ b/contact/index.md
@@ -12,10 +12,10 @@ description: "Start a conversation with James Pearson about analytics, experimen
 
 {% capture contact_form %}
   <form action="https://formspree.io/f/xovkjwgg" method="POST" class="grid md:grid-cols-2 gap-4">
-    <input type="text" name="name" placeholder="Name" class="bg-brandblack/70 border border-white/20 rounded-lg px-4 py-3 focus:border-brandblue focus:outline-none" required>
-    <input type="email" name="email" placeholder="Work email" class="bg-brandblack/70 border border-white/20 rounded-lg px-4 py-3 focus:border-brandblue focus:outline-none" required>
-    <input type="text" name="company" placeholder="Company" class="bg-brandblack/70 border border-white/20 rounded-lg px-4 py-3 md:col-span-2 focus:border-brandblue focus:outline-none">
-    <textarea name="message" placeholder="What do you need?" class="bg-brandblack/70 border border-white/20 rounded-lg px-4 py-3 md:col-span-2 focus:border-brandblue focus:outline-none" rows="5" required></textarea>
+    <input type="text" name="name" placeholder="Name" class="bg-white border border-brandblack/10 dark:bg-brandblack/70 dark:border-white/20 rounded-lg px-4 py-3 focus:border-brandblue focus:outline-none transition" required>
+    <input type="email" name="email" placeholder="Work email" class="bg-white border border-brandblack/10 dark:bg-brandblack/70 dark:border-white/20 rounded-lg px-4 py-3 focus:border-brandblue focus:outline-none transition" required>
+    <input type="text" name="company" placeholder="Company" class="bg-white border border-brandblack/10 dark:bg-brandblack/70 dark:border-white/20 rounded-lg px-4 py-3 md:col-span-2 focus:border-brandblue focus:outline-none transition">
+    <textarea name="message" placeholder="What do you need?" class="bg-white border border-brandblack/10 dark:bg-brandblack/70 dark:border-white/20 rounded-lg px-4 py-3 md:col-span-2 focus:border-brandblue focus:outline-none transition" rows="5" required></textarea>
     <button type="submit" class="bg-brandyellow text-brandblack font-semibold rounded-xl px-6 py-3 md:col-span-2">Send</button>
   </form>
 {% endcapture %}
@@ -38,10 +38,10 @@ description: "Start a conversation with James Pearson about analytics, experimen
     {% capture linkedin_panel %}
       <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div class="space-y-1">
-          <p class="font-medium text-white/90">Connect on LinkedIn</p>
-          <p class="text-sm text-white/60">Stay up to date with analytics insights and message James directly.</p>
+          <p class="font-medium text-brandblack/90 dark:text-white/90">Connect on LinkedIn</p>
+          <p class="text-sm text-brandblack/60 dark:text-white/60">Stay up to date with analytics insights and message James directly.</p>
         </div>
-        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition" target="_blank" rel="noopener">
+        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-brandblack/20 text-brandblack/80 hover:text-brandblue dark:border-white/20 dark:text-white/80 dark:hover:text-white transition" target="_blank" rel="noopener">
           <span>View profile</span>
         </a>
       </div>

--- a/index.md
+++ b/index.md
@@ -10,23 +10,23 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
     <p class="text-lg max-w-2xl">
       I run a Carlisle analytics consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
-    <div class="flex flex-wrap gap-3 text-sm md:text-base text-white/80">
-      <div class="px-4 py-2 rounded-xl border border-white/10 bg-white/5">
-        <span class="block font-semibold text-white">Fraud cut 10% → 0.6%</span>
-        <span class="block text-xs md:text-sm text-white/70">Marketplace (EU) trust &amp; safety</span>
+    <div class="flex flex-wrap gap-3 text-sm md:text-base text-brandblack/80 dark:text-white/80">
+      <div class="px-4 py-2 rounded-xl border border-brandblack/10 bg-brandblack/5 dark:border-white/10 dark:bg-white/5">
+        <span class="block font-semibold text-brandblack dark:text-white">Fraud cut 10% → 0.6%</span>
+        <span class="block text-xs md:text-sm text-brandblack/70 dark:text-white/70">Marketplace (EU) trust &amp; safety</span>
       </div>
-      <div class="px-4 py-2 rounded-xl border border-white/10 bg-white/5">
-        <span class="block font-semibold text-white">+10% daily revenue uplift</span>
-        <span class="block text-xs md:text-sm text-white/70">Xcelirate pricing science</span>
+      <div class="px-4 py-2 rounded-xl border border-brandblack/10 bg-brandblack/5 dark:border-white/10 dark:bg-white/5">
+        <span class="block font-semibold text-brandblack dark:text-white">+10% daily revenue uplift</span>
+        <span class="block text-xs md:text-sm text-brandblack/70 dark:text-white/70">Xcelirate pricing science</span>
       </div>
-      <div class="px-4 py-2 rounded-xl border border-white/10 bg-white/5">
-        <span class="block font-semibold text-white">Self-serve usage tripled</span>
-        <span class="block text-xs md:text-sm text-white/70">Series C SaaS metrics layer</span>
+      <div class="px-4 py-2 rounded-xl border border-brandblack/10 bg-brandblack/5 dark:border-white/10 dark:bg-white/5">
+        <span class="block font-semibold text-brandblack dark:text-white">Self-serve usage tripled</span>
+        <span class="block text-xs md:text-sm text-brandblack/70 dark:text-white/70">Series C SaaS metrics layer</span>
       </div>
     </div>
     <div class="flex flex-wrap gap-4">
-      <a href="/contact/" class="px-5 py-3 bg-brandblue text-white rounded-xl">Book a call</a>
-      <a href="/services/" class="px-5 py-3 border border-white/30 rounded-xl">View services</a>
+      <a href="/contact/" class="px-5 py-3 bg-brandblue text-white rounded-xl hover:bg-brandblue/90 transition">Book a call</a>
+      <a href="/services/" class="px-5 py-3 border border-brandblack/30 dark:border-white/30 rounded-xl hover:border-brandblue/60 transition">View services</a>
     </div>
   </div>
 {% endcapture %}
@@ -39,7 +39,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
       <h2 class="text-3xl font-semibold">{{ home_services.title }}</h2>
       <p class="mt-2 opacity-80 max-w-2xl">{{ home_services.description }}</p>
     </div>
-    <a href="{{ home_services.view_all.url }}" class="inline-flex px-5 py-3 bg-brandblue text-white rounded-xl text-sm uppercase tracking-wide">{{ home_services.view_all.label }}</a>
+    <a href="{{ home_services.view_all.url }}" class="inline-flex px-5 py-3 bg-brandblue text-white rounded-xl text-sm uppercase tracking-wide hover:bg-brandblue/90 transition">{{ home_services.view_all.label }}</a>
   </div>
 {% endcapture %}
 {% assign services = site.services | sort: 'position' %}
@@ -55,7 +55,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
           {% if service.focus %}
             <ul class="mt-auto text-xs uppercase tracking-wide opacity-70 flex flex-wrap gap-2">
               {% for item in service.focus %}
-                <li class="px-2 py-1 rounded-full border border-white/10">{{ item }}</li>
+                <li class="px-2 py-1 rounded-full border border-brandblack/20 dark:border-white/10">{{ item }}</li>
               {% endfor %}
             </ul>
           {% endif %}
@@ -80,7 +80,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
       <h2 class="text-3xl font-semibold">{{ home_work.title }}</h2>
       <p class="mt-2 opacity-80 max-w-2xl">{{ home_work.description }}</p>
     </div>
-    <a href="{{ home_work.view_all.url }}" class="inline-flex px-5 py-3 bg-brandblue text-white rounded-xl text-sm uppercase tracking-wide">{{ home_work.view_all.label }}</a>
+    <a href="{{ home_work.view_all.url }}" class="inline-flex px-5 py-3 bg-brandblue text-white rounded-xl text-sm uppercase tracking-wide hover:bg-brandblue/90 transition">{{ home_work.view_all.label }}</a>
   </div>
 {% endcapture %}
 {% assign featured_work = site.work | where_exp: 'item', 'item.featured != false' | sort: 'position' %}

--- a/services/index.html
+++ b/services/index.html
@@ -92,12 +92,12 @@ description: "Consultancy engagements covering data platforms, analytics, experi
             {% if service.focus %}
               <ul class="pt-1 text-xs uppercase tracking-wide opacity-70 flex flex-wrap gap-2">
                 {% for item in service.focus %}
-                  <li class="px-2 py-1 rounded-full border border-white/10">{{ item }}</li>
+                  <li class="px-2 py-1 rounded-full border border-brandblack/20 dark:border-white/10">{{ item }}</li>
                 {% endfor %}
               </ul>
             {% endif %}
           </header>
-          <div class="prose prose-invert max-w-none text-sm">
+          <div class="prose prose-neutral dark:prose-invert max-w-none text-sm">
             {{ service.content | markdownify }}
           </div>
           <a href="{{ service.url }}" class="text-sm text-brandblue mt-auto">View service →</a>
@@ -151,7 +151,7 @@ description: "Consultancy engagements covering data platforms, analytics, experi
         <p class="text-sm opacity-80">Ready to explore a project?</p>
         <div class="flex flex-col gap-3">
           <a href="{{ page_content.ctas.primary.url }}" class="px-5 py-3 bg-brandblue text-white rounded-xl text-center">{{ page_content.ctas.primary.label }}</a>
-          <a href="{{ page_content.ctas.secondary.url }}" class="px-5 py-3 border border-white/20 rounded-xl text-center">{{ page_content.ctas.secondary.label }}</a>
+          <a href="{{ page_content.ctas.secondary.url }}" class="px-5 py-3 border border-brandblack/20 dark:border-white/20 rounded-xl text-center">{{ page_content.ctas.secondary.label }}</a>
         </div>
       </div>
     {% endcapture %}

--- a/work/index.html
+++ b/work/index.html
@@ -85,7 +85,7 @@ description: "Case studies featuring fraud reduction, revenue optimisation, and 
           <ol class="space-y-3 text-sm opacity-80">
             {% for step in page_content.process.steps %}
               <li>
-                <span class="block font-semibold text-white">{{ step.title }}</span>
+                <span class="block font-semibold text-brandblack dark:text-white">{{ step.title }}</span>
                 <span>{{ step.detail }}</span>
               </li>
             {% endfor %}


### PR DESCRIPTION
## Summary
- add persistent light/dark theme handling with early-load detection and toggle scripts shared across the layout and footer
- refresh the header navigation with desktop and mobile theme toggle controls and palette-aware styling
- update shared sections, panels, and key content pages so text, borders, and surfaces render appropriately in both themes

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing in environment)*
