### PR TITLE
Default to light theme and refresh third-person copy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,14 +40,14 @@ company:
   legal_name: "Etterby Analytics Ltd"
   url: "https://etterby.com"
   email: "hello@etterby.com"
-  description: "Independent analytics consultancy led by James Pearson delivering data platforms, experimentation, and forecasting."
+  description: "Independent analytics consultancy delivering data platforms, experimentation, and forecasting."
   logo: "/assets/og-image.png"
   same_as:
-    - "https://www.linkedin.com/in/james-pearson-data/"
+    - "https://www.linkedin.com/company/etterby-analytics/"
   address:
     street_address: "Remote-first"
     address_locality: "London"
     address_region: "England"
     postal_code: ""
     address_country: "GB"
-  founder: "James Pearson"
+  founder: "Founder-led analytics team"

--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -1,16 +1,16 @@
 hero:
-  eyebrow: "About James Pearson"
-  title: "Analytics leadership that pairs craft with commercial impact"
+  eyebrow: "About Etterby Analytics"
+  title: "Founder-led analytics with measurable outcomes"
   description:
-    - "Based in Carlisle, I operate as an embedded lead analyst for high-growth teams - shipping the infrastructure, decision science, and enablement that turn data into revenue, resilience, and trust across the UK and beyond."
-    - "Across Cumbria organisations, UK scale-ups, and selected global marketplaces, SaaS platforms, and media, I have built data functions from scratch, modernised analytics programmes, and mentored analysts to operate with confidence."
+    - "Etterby Analytics is an independent consultancy based in Carlisle, partnering with product and operations teams to make better commercial decisions with reliable data."
+    - "Engagements pair on-site work across Cumbria with remote collaboration for UK organisations and select global partners, focusing every project on tangible improvements to revenue, trust, or efficiency."
 profile:
-  title: "Founder & Lead Analyst"
-  name: "James Pearson"
+  title: "Founder-led delivery"
+  name: "Carlisle-based leadership"
   bio:
-    - "Lead Data Analyst at Xcelirate (contract) delivering fraud prevention, price optimisation, and forecasting systems."
-    - "Former Senior Data Analyst at Vita Mojo, rolling out ThoughtSpot across global enterprise clients."
-    - "11+ years in analytics roles spanning experimentation, customer insight, and CRM strategy."
+    - "Led by an embedded analytics founder with more than a decade delivering experimentation, forecasting, and BI programmes."
+    - "Hands-on across discovery, modelling, and enablement to make sure capability stays inside your organisation."
+    - "Trusted by marketplaces, SaaS scale-ups, and hospitality brands needing resilient data foundations and accountable outcomes."
 values:
   title: "Principles that guide every engagement"
   items:
@@ -29,66 +29,8 @@ credentials:
 contact_cta:
   label: "Book a working session"
   url: "/contact/"
-cv:
-  title: "Curriculum vitae"
-  intro: "Highlights from the last decade of building analytics teams, platforms, and revenue-critical models."
-  download:
-    label: "Request the full CV"
-    url: "mailto:hello@etterby.com?subject=CV%20request"
-  experience:
-    recent_roles:
-      - role: "Lead Data Analyst"
-        company: "Xcelirate (Contract)"
-        location: "Remote"
-        period: "Jul 2019 – Present"
-        highlights:
-          - "Built a modern analytics stack with ClickHouse, Airflow, dbt, and Superset for faster decision-making."
-          - "Designed Python/Flask fraud models with 86% detection at 97% precision, cutting fraud to 0.6%."
-          - "Delivered price optimisation, lifecycle, and forecasting models adopted across finance and product."
-          - "Led hiring and mentoring of analysts while running agile ceremonies with the executive team."
-      - role: "Senior Data Analyst"
-        company: "Vita Mojo"
-        location: "London (Remote)"
-        period: "Aug 2022 – Aug 2024"
-        highlights:
-          - "Implemented ThoughtSpot for internal teams and brands such as Subway, Leon, and Black Sheep Coffee."
-          - "Modelled KPIs, dashboards, and embedded analytics inside client platforms to standardise reporting."
-          - "Trained stakeholders to drive adoption of self-serve analytics and governed data definitions."
-      - role: "Customer Behavioural Insight Analyst"
-        company: "The Stars Group"
-        location: "Leeds"
-        period: "Oct 2018 – Jul 2019"
-        highlights:
-          - "Automated A/B test analysis in R to inform product decisions."
-          - "Built predictive next-deposit models that increased transaction value at payment."
-          - "Delivered funnel analytics for onboarding and payments using BigQuery."
-      - role: "Senior Insight Analyst"
-        company: "Premier Farnell UK Ltd"
-        location: "Leeds"
-        period: "Oct 2017 – Oct 2018"
-        highlights:
-          - "Developed product recommendation models delivering ~10% cross-sell uplift."
-          - "Integrated churn propensity modelling into Salesforce to prioritise sales outreach."
-          - "Created marketing attribution that improved budget allocation."
-    early_career:
-      title: "Early career"
-      roles:
-        - "CRM Insight Analyst · Wunderman UK · London · Dec 2016 – May 2017"
-        - "SQL Reporting Analyst · Karhoo (Contract) · London · Sep 2016 – Nov 2016"
-        - "Data Analyst · Zone (Contract) · London · Jun 2016 – Sep 2016"
-        - "Data Analyst · MixRadio · Bristol · Aug 2015 – May 2016"
-        - "Data Analyst · Grosvenor Casinos, Rank Group PLC · London · Aug 2012 – Aug 2015"
-  skills:
-    title: "Skills & competencies"
-    categories:
-      - name: "Technical"
-        detail: "Python (pandas, NumPy, scikit-learn), R, SQL (Postgres, MySQL, Redshift, ClickHouse, BigQuery)"
-      - name: "Data platforms"
-        detail: "Airflow, dbt, Superset, ThoughtSpot, Power BI, Tableau, MixPanel, Google Analytics"
-      - name: "Delivery"
-        detail: "Experimentation, forecasting, revenue optimisation, fraud detection"
-      - name: "Leadership"
-        detail: "Team building, mentoring, agile facilitation, executive storytelling"
-  education:
-    title: "Education"
-    detail: "BSc (Hons) Mathematics, University of Bristol - 2009-2012 (focus on statistical analysis with first-class grades across statistics modules)."
+story:
+  title: "A different kind of analytics partner"
+  paragraphs:
+    - "The consultancy was created to give growth teams senior analytics leadership without the overhead that comes with large agencies. Every engagement is delivered by the founder, not a rotating squad of juniors."
+    - "Competitors often prioritise headcount and billable hours. Etterby Analytics focuses on a smaller roster of clients, keeping execution close to decision-makers and sharing playbooks so internal teams stay confident after handover."

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -1,6 +1,6 @@
 services:
   title: "Services"
-  description: "Engagements led from Carlisle by James Pearson to modernise data platforms, run experimentation programmes, and ship predictive models for teams across Cumbria, the wider UK, and select global partners."
+  description: "Engagements led from Carlisle by Etterby Analytics to modernise data platforms, run experimentation programmes, and ship predictive models for teams across Cumbria, the wider UK, and select global partners."
   view_all:
     label: "Explore all services"
     url: "/services/"

--- a/_data/insights_page.yml
+++ b/_data/insights_page.yml
@@ -17,6 +17,6 @@ categories:
       detail: "Forecasting demand, modelling elasticity, and aligning finance with product."
 newsletter:
   title: "Ready to discuss your next analytics milestone?"
-  body: "Share the outcomes you are targeting and I will map the fastest path to get there."
+  body: "Share the outcomes you are targeting and Etterby Analytics will map the fastest path to get there."
   cta_label: "Contact"
   cta_url: "/contact/"

--- a/_data/services_page.yml
+++ b/_data/services_page.yml
@@ -1,9 +1,9 @@
 hero:
-  eyebrow: "How we help"
+  eyebrow: "How Etterby Analytics helps"
   title: "Embedded analytics leadership for complex decisions"
   description:
-    - "James Pearson works hands-on from Carlisle with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement UK-first companies need to move faster."
-    - "On-site sessions across Cumbria pair with remote collaboration that prioritises UK teams while remaining open to select global partners, with engagements scoped around measurable outcomes - fraud reduction, revenue uplift, adoption - and coaching for your internal teams."
+    - "Etterby Analytics embeds founder-led analytics leadership with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement UK-first companies need to move faster."
+    - "On-site sessions across Cumbria pair with remote collaboration for organisations across the UK and select global partners, with engagements scoped around measurable outcomes such as fraud reduction, revenue uplift, or adoption."
     - "Recent work spans GA4 instrumentation, self-serve dashboard design, and executive storytelling for global restaurant and retail brands."
 service_models:
   title: "Common engagement patterns"
@@ -18,7 +18,7 @@ service_models:
       duration: "Quarterly engagement"
       detail: "Ongoing partnership covering forecasting, pricing optimisation, and executive enablement with a clear cadence of deliverables."
 collaboration:
-  title: "How we collaborate"
+  title: "How Etterby Analytics collaborates"
   points:
     - "Dedicated Slack channel with <24h async response times"
     - "Weekly steering with conversion, revenue, or fraud metrics reviewed against targets"

--- a/_data/work_page.yml
+++ b/_data/work_page.yml
@@ -5,7 +5,7 @@ hero:
     - "Each engagement blends data engineering, experimentation, and enablement. The focus: measurable shifts in fraud, revenue, or adoption that sustain after handover."
     - "Highlights include GA4 tagging recoveries, franchise dashboard relaunches, and revenue experimentation embedded with client teams."
 filters:
-  title: "What we deliver"
+  title: "What Etterby Analytics delivers"
   items:
     - "Data platforms & reliability"
     - "Decision-ready analytics"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
     <span>·</span>
     <a href="/terms/" class="hover:text-brandblack dark:hover:text-white transition">Terms</a>
     <span>·</span>
-    <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+    <a href="https://www.linkedin.com/company/etterby-analytics/" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
     <span class="md:ml-auto text-brandblack/60 dark:text-white/60">Analytics leadership since 2012</span>
   </div>
 </footer>
@@ -59,14 +59,7 @@
     if (currentPreference) {
       applyTheme(currentPreference);
     } else {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-      applyTheme(prefersDark.matches ? 'dark' : 'light');
-      prefersDark.addEventListener('change', (event) => {
-        const stored = getStoredTheme();
-        if (!stored) {
-          applyTheme(event.matches ? 'dark' : 'light');
-        }
-      });
+      applyTheme('light');
     }
 
     if (themeButtons.length) {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
           <span class="inline-flex h-2 w-2 rounded-full bg-brandblack dark:bg-white"></span>
           <span data-theme-toggle-label>Dark mode</span>
         </button>
-        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/etterby-analytics/" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
         <a href="/contact/" class="inline-flex items-center justify-center px-4 py-2 rounded-lg border border-brandblue/60 text-brandblack dark:text-white hover:bg-brandblue hover:border-brandblue hover:text-white transition">Work together</a>
       </nav>
     </div>
@@ -28,7 +28,7 @@
         <span class="inline-flex h-2 w-2 rounded-full bg-brandblack dark:bg-white"></span>
         <span data-theme-toggle-label>Dark mode</span>
       </button>
-      <a href="https://www.linkedin.com/in/james-pearson-etterby" class="py-1 hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://www.linkedin.com/company/etterby-analytics/" class="py-1 hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/contact/" class="mt-2 inline-flex items-center justify-center px-4 py-2 rounded-lg bg-brandblue text-white">Work together</a>
     </div>
   </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,8 +57,7 @@
       };
 
       const stored = getStoredTheme();
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const shouldUseDark = stored === 'dark' || (stored === null && prefersDark);
+      const shouldUseDark = stored === 'dark';
 
       root.classList.toggle('dark', shouldUseDark);
       root.dataset.theme = shouldUseDark ? 'dark' : 'light';

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,7 +51,7 @@ layout: default
       {% capture challenge_panel %}
         <div class="space-y-3">
           <h2 class="text-lg font-semibold">Talk through your own challenge</h2>
-          <p class="text-sm text-brandblack/70 dark:text-white/70">Share the context behind your data and analytics goals and we'll map the fastest path to value.</p>
+          <p class="text-sm text-brandblack/70 dark:text-white/70">Share the context behind your data and analytics goals and Etterby Analytics will map the fastest path to value.</p>
           <a href="/contact/" class="inline-flex items-center justify-center px-5 py-3 bg-brandblue text-white rounded-xl text-sm font-medium hover:bg-brandblue/80 transition">Book a call</a>
         </div>
       {% endcapture %}

--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -41,7 +41,7 @@ layout: default
       {% capture call_panel %}
         <div class="space-y-3">
           <h2 class="text-lg font-semibold">Book a call</h2>
-          <p class="text-sm opacity-80">Share your goals and we will map the quickest route to value.</p>
+          <p class="text-sm opacity-80">Share your goals and Etterby Analytics will map the quickest route to value.</p>
           <a href="/contact/" class="block px-5 py-3 bg-brandblue text-white rounded-xl text-center">Discuss your project</a>
         </div>
       {% endcapture %}

--- a/_posts/2025-09-21-clickhouse-vs-postgres.md
+++ b/_posts/2025-09-21-clickhouse-vs-postgres.md
@@ -4,9 +4,9 @@ title: "When ClickHouse shines"
 
 Where columnar OLAP wins for event data and how to roll it out pragmatically.
 
-The decision to introduce ClickHouse at Xcelirate came after months of watching Postgres wheeze under customer events. Analysts needed multi month lookbacks to explain fraud patterns and the row store was not built for that scale. ClickHouse gave us sub second responses on the same hardware once we modelled the data around the questions product and risk teams asked every week.
+The decision to introduce ClickHouse at Xcelirate came after months of watching Postgres wheeze under customer events. Analysts needed multi month lookbacks to explain fraud patterns and the row store was not built for that scale. ClickHouse delivered sub-second responses on the same hardware once the team modelled the data around the questions product and risk teams asked every week.
 
-It is not a silver bullet though. For transactional workloads and operational updates, Postgres remains the system of record. The winning pattern has been to stream change data capture into ClickHouse, apply dbt for modelling, and keep Postgres for writes and mission critical OLTP. That mirrors how we rolled out analytics at Vita Mojo where Looker and ThoughtSpot relied on consistent semantics built on top of the warehouse.
+It is not a silver bullet though. For transactional workloads and operational updates, Postgres remains the system of record. The winning pattern for Etterby Analytics has been to stream change data capture into ClickHouse, apply dbt for modelling, and keep Postgres for writes and mission critical OLTP. That mirrors how the team rolled out analytics at Vita Mojo where Looker and ThoughtSpot relied on consistent semantics built on top of the warehouse.
 
-Success hinges on enablement. Engineers needed cheat sheets for materialised views, analysts required query templates, and leadership wanted clear SLAs. By pairing the migration with documentation and training, we made ClickHouse an accelerator rather than a distraction.
+Success hinges on enablement. Engineers needed cheat sheets for materialised views, analysts required query templates, and leadership wanted clear SLAs. By pairing the migration with documentation and training, the consultancy made ClickHouse an accelerator rather than a distraction.
 

--- a/_posts/2025-09-21-from-heuristics-to-ml.md
+++ b/_posts/2025-09-21-from-heuristics-to-ml.md
@@ -4,9 +4,9 @@ title: "From heuristics to ML"
 
 Shadow evaluation, thresholds, and change management that sticks.
 
-When marketplaces asked for machine learning to replace the heuristics their operations teams had curated for years, I pushed for quiet launches first. We rebuilt the checks as Python services, ran them alongside the legacy rules, and compared every alert. That shadow period exposed blind spots without taking unnecessary risks.
+When marketplaces asked for machine learning to replace the heuristics their operations teams had curated for years, Etterby Analytics pushed for quiet launches first. The team rebuilt the checks as Python services, ran them alongside the legacy rules, and compared every alert. That shadow period exposed blind spots without taking unnecessary risks.
 
-Only once precision and recall cleared the thresholds agreed with finance and compliance did we talk about full go live. Documentation, retraining cadences, and rollback paths were written before we made the switch. Those controls are the reason the fraud programmes I led at Xcelirate and The Stars Group hit targets without disrupting good customers.
+Only once precision and recall cleared the thresholds agreed with finance and compliance did the consultancy recommend a full go live. Documentation, retraining cadences, and rollback paths were written before the switch. Those controls are the reason the fraud programmes led at Xcelirate and The Stars Group hit targets without disrupting good customers.
 
 Technology is the easy part. The harder work is showing frontline teams how their expertise shaped the model and giving them avenues to override with reason. Working sessions, release notes, and a cadence for feedback help the change land. The same playbook translated to deploying experimentation platforms and pricing models across distributed Vita Mojo teams.
 

--- a/_posts/2025-09-21-outcome-first-analytics.md
+++ b/_posts/2025-09-21-outcome-first-analytics.md
@@ -4,9 +4,9 @@ title: "Outcome-first analytics"
 
 Prioritise decisions and measurable change over tooling debates. A simple playbook that aligns data work to outcomes.
 
-Every engagement starts with the same exercise I run with founders at Xcelirate and restaurant leaders at Vita Mojo. We list the commercial metrics that matter this quarter, the operational guardrails that cannot move, and the people accountable for each. That clarity stops scope creep before it starts and keeps analysts from chasing dashboard vanity projects.
+Every engagement starts with the same exercise the founder runs with product and operations leaders across Xcelirate, Vita Mojo, and other partners. The team lists the commercial metrics that matter this quarter, the operational guardrails that cannot move, and the people accountable for each. That clarity stops scope creep before it starts and keeps analysts from chasing dashboard vanity projects.
 
-From there I map the smallest analytical delivery that creates feedback. At Xcelirate that meant instrumenting fraud funnels and forecasting the exposure in cash terms. At Vita Mojo it was an executive scorecard that made adoption progress visible week by week. Each increment has an owner, a baseline, and a plan to iterate if the first release only gets us part way.
+From there Etterby Analytics maps the smallest analytical delivery that creates feedback. At Xcelirate that meant instrumenting fraud funnels and forecasting the exposure in cash terms. At Vita Mojo it was an executive scorecard that made adoption progress visible week by week. Each increment has an owner, a baseline, and a plan to iterate if the first release only gets part of the way.
 
-The last layer is enablement so teams can continue without me. Shadowing sessions, playbooks, and simple governance tables make sure context is shared and decisions are reproducible. It is the same approach that helped ThoughtSpot adoption stick with enterprise brands and kept finance, product, and operations aligned around the same numbers.
+The last layer is enablement so teams can continue without relying on external support. Shadowing sessions, playbooks, and simple governance tables make sure context is shared and decisions are reproducible. It is the same approach that helped ThoughtSpot adoption stick with enterprise brands and kept finance, product, and operations aligned around the same numbers.
 

--- a/_posts/2025-09-22-designing-self-service-dashboards.md
+++ b/_posts/2025-09-22-designing-self-service-dashboards.md
@@ -4,8 +4,8 @@ title: "Designing dashboards people actually use"
 
 Wireframes and hero metrics are table stakes. The dashboards that stick pair narrative, diagnostics, and ritual.
 
-While leading analytics for Subway franchisees and Vita Mojo operators we started every build by interviewing the people opening the dashboard each morning. Their questions shaped the first three tiles, the comparisons, and the alerting rules. Without that context the prettiest layout still sent users back to spreadsheets.
+While leading analytics for Subway franchisees and Vita Mojo operators, Etterby Analytics started every build by interviewing the people opening the dashboard each morning. Their questions shaped the first three tiles, the comparisons, and the alerting rules. Without that context the prettiest layout still sent users back to spreadsheets.
 
-The second ingredient is performance. ThoughtSpot, Power BI, and Hex are only self-serve if they stay sub-second and the data definitions line up with finance. That meant investing as much time in dbt models, caching, and observability as we did in colours and chart types.
+The second ingredient is performance. ThoughtSpot, Power BI, and Hex are only self-serve if they stay sub-second and the data definitions line up with finance. That meant investing as much time in dbt models, caching, and observability as in colours and chart types.
 
-Finally we handed over more than a link. Every launch included release notes, loom walk-throughs, telemetry, and a playbook for how to request tweaks. Adoption is a product, not a deliverable, and treating it like one turns dashboards into decision engines.
+Finally the consultancy handed over more than a link. Every launch included release notes, loom walk-throughs, telemetry, and a playbook for how to request tweaks. Adoption is a product, not a deliverable, and treating it like one turns dashboards into decision engines.

--- a/_posts/2025-09-22-ga4-tagging-governance.md
+++ b/_posts/2025-09-22-ga4-tagging-governance.md
@@ -4,8 +4,8 @@ title: "Making GA4 tagging dependable"
 
 The GA4 rush left many teams with brittle instrumentation and consent gaps. Fixing it starts with ownership.
 
-When I supported a private equity portfolio on their GA4 migration the first win was agreeing who owned each step: agencies handled creative, but measurement planning, QA, and release notes lived with the internal analytics squad. That alignment alone stopped three launch-day outages.
+When Etterby Analytics supported a private equity portfolio on its GA4 migration the first win was agreeing who owned each step: agencies handled creative, but measurement planning, QA, and release notes lived with the internal analytics squad. That alignment alone stopped three launch-day outages.
 
-Next came automation. We wired server-side tagging, wrote dbt tests against the export tables, and hooked up Slack alerts when payloads drifted. Manual spot checks still mattered, but the guardrails caught issues before revenue reporting went sideways.
+Next came automation. The team wired server-side tagging, wrote dbt tests against the export tables, and hooked up Slack alerts when payloads drifted. Manual spot checks still mattered, but the guardrails caught issues before revenue reporting went sideways.
 
-Finally we treated documentation as a product. Every change shipped with measurement diagrams, consent implications, and a rollback plan. It gave marketing the confidence to move fast without sacrificing data quality—or inviting regulators to the party.
+Finally the team treated documentation as a product. Every change shipped with measurement diagrams, consent implications, and a rollback plan. It gave marketing the confidence to move fast without sacrificing data quality—or inviting regulators to the party.

--- a/_services/analytics-bi.md
+++ b/_services/analytics-bi.md
@@ -10,7 +10,7 @@ focus:
   - Enablement
 ---
 
-**Where we start**
+**Where each engagement starts**
 - Map critical decisions, data sources, and the definitions that are currently disputed
 - Design a governed semantic layer or ThoughtSpot/BI model that reflects how teams operate
 - Prioritise the dashboards, alerts, and self-serve journeys that matter for revenue and operations

--- a/_services/data-platforms-reliability.md
+++ b/_services/data-platforms-reliability.md
@@ -3,14 +3,14 @@ title: "Data Platforms & Reliability"
 position: 1
 tagline: "Modern ELT with dbt, Airflow, and ClickHouse built for scale."
 summary: "Versioned pipelines, observability, and governance that keep metrics trustworthy across teams."
-description: "Design and deliver resilient analytics stacks drawing on James Pearson's work at Xcelirate, Vita Mojo, and high-growth marketplaces."
+description: "Design and deliver resilient analytics stacks drawing on founder-led work at Xcelirate, Vita Mojo, and high-growth marketplaces."
 focus:
   - Data Contracts
   - Observability
   - Governance
 ---
 
-**Where we start**
+**Where each engagement starts**
 - Run a readiness audit across ingestion, transformation, and data contracts
 - Introduce modular dbt patterns, CI/CD, and testing that match your team structure
 - Stand up observability with freshness SLAs, anomaly detection, and stakeholder alerts

--- a/_services/digital-analytics-tagging.md
+++ b/_services/digital-analytics-tagging.md
@@ -3,14 +3,14 @@ title: "Tagging & Digital Analytics Foundations"
 position: 2
 tagline: "Instrumentation, consent, and GA4 tracking that marketing and product can trust."
 summary: "Stabilise Google Analytics, GTM, and consent journeys so every campaign and funnel report is decision-ready."
-description: "Grounded in James Pearson's work modernising Vita Mojo's restaurant analytics and advising PE-backed retail brands."
+description: "Grounded in founder-led work modernising Vita Mojo's restaurant analytics and advising PE-backed retail brands."
 focus:
   - GA4 & GTM
   - Consent Governance
   - Event Design
 ---
 
-**Where we start**
+**Where each engagement starts**
 - Audit GA4 properties, GTM containers, and consent flows against regulatory and commercial requirements
 - Map high-value journeys across web, app, and kiosk to align event naming and parameters with revenue goals
 - Prioritise fixes and net-new instrumentation with an agreed backlog, owners, and implementation plan

--- a/_services/experimentation-forecasting-applied-ml.md
+++ b/_services/experimentation-forecasting-applied-ml.md
@@ -3,14 +3,14 @@ title: "Experimentation, Forecasting & Applied ML"
 position: 5
 tagline: "Practical models and test programmes tied directly to commercial metrics."
 summary: "Frame the decision, design robust experiments or models, and keep them accountable in production."
-description: "From fraud detection to revenue forecasting, every build is anchored in James Pearson's decade leading decision science."
+description: "From fraud detection to revenue forecasting, every build is anchored in a decade of founder-led decision science delivery."
 focus:
   - Experimentation
   - Forecasting
   - Decision Science
 ---
 
-**Where we start**
+**Where each engagement starts**
 - Quantify the decision, counterfactual, and target KPIs with stakeholders
 - Audit data availability, labelling, and historic experiments to ground the roadmap
 - Design delivery phases that balance exploration, productionisation, and enablement

--- a/_services/revenue-lifecycle-intelligence.md
+++ b/_services/revenue-lifecycle-intelligence.md
@@ -10,7 +10,7 @@ focus:
   - Lifecycle
 ---
 
-**Where we start**
+**Where each engagement starts**
 - Understand the revenue motions, lifecycle triggers, and decisions you need to influence
 - Audit historic pricing tests, retention cohorts, and data availability
 - Co-create a roadmap covering modelling, experimentation, and communication milestones

--- a/_services/self-service-dashboards.md
+++ b/_services/self-service-dashboards.md
@@ -3,14 +3,14 @@ title: "Self-Service Dashboards & Embedded Analytics"
 position: 4
 tagline: "Design KPI stories and workflows that teams return to every day."
 summary: "Craft ThoughtSpot, Power BI, and Hex experiences that answer follow-up questions and unlock adoption."
-description: "Built from James Pearson's delivery for Subway franchisees, Vita Mojo operators, and private equity portfolio reviews."
+description: "Built from founder-led delivery for Subway franchisees, Vita Mojo operators, and private equity portfolio reviews."
 focus:
   - Dashboard Design
   - Embedded Workflows
   - Adoption
 ---
 
-**Where we start**
+**Where each engagement starts**
 - Review existing dashboards and stakeholder interviews to understand the questions that matter most
 - Prioritise personas and decision moments, then wireframe stories that surface the right metrics and diagnostics
 - Pair design with data modelling and performance tuning so dashboards stay fast and reliable in production

--- a/_work/fraud-detection-eu-classifieds.md
+++ b/_work/fraud-detection-eu-classifieds.md
@@ -9,7 +9,7 @@ duration: "16 weeks"
 position: 1
 featured: true
 summary: "Rebuilt trust & safety analytics and launched fraud models that cut abusive users from 10% to 0.6%."
-description: "James Pearson led delivery end-to-end - from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
+description: "Founder-led delivery end-to-end - from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
 results:
   - "Reduced fraudulent users from 10% to 0.6% at 97% precision and 86% detection."
   - "Average detection window improved by 40 days with automated takedown workflows."

--- a/_work/ga4-tagging-retail-portfolio.md
+++ b/_work/ga4-tagging-retail-portfolio.md
@@ -9,7 +9,7 @@ duration: "8 weeks"
 position: 4
 featured: false
 summary: "Stabilised Google Analytics, consent flows, and campaign attribution across five portfolio brands."
-description: "James Pearson led the tagging migration and governance playbook so marketing and product teams could rely on GA4 and BigQuery for decision-making."
+description: "Founder-led tagging migration and governance playbooks so marketing and product teams could rely on GA4 and BigQuery for decision-making."
 results:
   - "Unified GTM containers with consent-aware deployment and automated QA."
   - "GA4 to BigQuery export powering merchandising and acquisition dashboards within four weeks."

--- a/_work/metrics-modernisation-b2b-saas.md
+++ b/_work/metrics-modernisation-b2b-saas.md
@@ -9,7 +9,7 @@ duration: "12 weeks"
 position: 3
 featured: true
 summary: "Delivered a governed metrics layer and ThoughtSpot rollout that aligned revenue and product teams."
-description: "James Pearson led the KPI framework, modelling, and enablement that standardised reporting for internal teams and enterprise restaurant brands."
+description: "Founder-led delivery across KPI frameworks, modelling, and enablement that standardised reporting for internal teams and enterprise restaurant brands."
 results:
   - "Unified metric definitions adopted by finance, sales, and product through governed models."
   - "ThoughtSpot dashboards embedded in client platforms with <2 minute load times for 120+ DAUs."

--- a/_work/price-optimisation-xcelirate.md
+++ b/_work/price-optimisation-xcelirate.md
@@ -9,7 +9,7 @@ duration: "10 weeks"
 position: 5
 featured: false
 summary: "Delivered dynamic pricing and forecasting models that lifted daily revenue by 10%."
-description: "James Pearson combined experimentation, predictive modelling, and stakeholder enablement to embed pricing science into commercial planning."
+description: "Founder-led experimentation, predictive modelling, and stakeholder enablement embedded pricing science into commercial planning."
 results:
   - "+10% daily revenue uplift within six weeks of launch."
   - "Automated revenue and user forecasts consumed by finance and leadership."

--- a/_work/self-service-dashboards-restaurant-group.md
+++ b/_work/self-service-dashboards-restaurant-group.md
@@ -9,7 +9,7 @@ duration: "14 weeks"
 position: 2
 featured: true
 summary: "Delivered franchise performance dashboards and enablement that unlocked daily self-serve usage."
-description: "James Pearson partnered with Subway International and Vita Mojo to redesign analytics for franchise owners and operator teams, pairing KPI storytelling with technical delivery."
+description: "Founder-led partnership with Subway International and Vita Mojo to redesign analytics for franchise owners and operator teams, pairing KPI storytelling with technical delivery."
 results:
   - "Franchisee dashboards adopted across 20+ markets with role-based navigation and automated commentary."
   - "Daily active users tripled as operators relied on guided analyses for staffing, menu, and promotions."
@@ -27,4 +27,4 @@ Operators were overwhelmed by ad-hoc spreadsheets and slow dashboards, making it
 ### Outcome
 - Weekly franchise reviews anchored on consistent dashboards and alerts
 - Reduced analyst support tickets as owners self-served diagnostics and exported recommendations
-- Ongoing roadmap owned by internal teams with James advising on quarterly enhancements
+- Ongoing roadmap owned by internal teams with the founder advising on quarterly enhancements

--- a/about/index.md
+++ b/about/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About"
-description: "Discover James Pearson's CV, values, and the analytics outcomes delivered across marketplaces, SaaS, and media."
+description: "Learn how Etterby Analytics operates, the founder-led principles behind the consultancy, and the outcomes delivered for product and operations teams."
 ---
 {% assign page_content = site.data.about_page %}
 {% capture about_hero %}
@@ -14,6 +14,16 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
   </div>
 {% endcapture %}
 {% include section.html tone="plain" padding="py-16" content=about_hero %}
+
+{% capture story_block %}
+  <div class="max-w-3xl space-y-4">
+    <h2 class="text-2xl font-semibold">{{ page_content.story.title }}</h2>
+    {% for paragraph in page_content.story.paragraphs %}
+      <p class="opacity-90">{{ paragraph }}</p>
+    {% endfor %}
+  </div>
+{% endcapture %}
+{% include section.html tone="frost" padding="py-12" content=story_block %}
 
 {% capture about_profile %}
   <div class="grid md:grid-cols-[2fr,1fr] gap-8 items-start">
@@ -66,7 +76,7 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
       {% capture contact_panel %}
         <div class="space-y-3 text-center">
           <h2 class="text-lg font-semibold">Ready to collaborate?</h2>
-          <p class="text-sm text-brandblack/70 dark:text-white/70">Discuss your analytics roadmap and the momentum we can unlock.</p>
+          <p class="text-sm text-brandblack/70 dark:text-white/70">Discuss your analytics roadmap and the momentum Etterby Analytics can unlock.</p>
           <a href="{{ page_content.contact_cta.url }}" class="inline-flex justify-center px-5 py-3 bg-brandblue text-white rounded-xl">{{ page_content.contact_cta.label }}</a>
         </div>
       {% endcapture %}
@@ -74,85 +84,4 @@ description: "Discover James Pearson's CV, values, and the analytics outcomes de
     </aside>
   </div>
 {% endcapture %}
-{% include section.html tone="frost" content=about_profile %}
-
-{% capture cv_intro %}
-  <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-    <div>
-      <h2 class="text-2xl font-semibold">{{ page_content.cv.title }}</h2>
-      <p class="opacity-80">{{ page_content.cv.intro }}</p>
-    </div>
-    <a href="{{ page_content.cv.download.url }}" class="inline-flex items-center justify-center px-5 py-3 border border-brandblack/30 dark:border-white/30 rounded-xl text-sm uppercase tracking-wide">{{ page_content.cv.download.label }}</a>
-  </div>
-{% endcapture %}
-
-{% capture cv_roles %}
-  <div class="space-y-6">
-    {% for role in page_content.cv.experience.recent_roles %}
-      {% capture role_panel %}
-        <div class="space-y-3">
-          <header>
-            <p class="text-xs uppercase tracking-wide opacity-70">{{ role.company }} · {{ role.location }}</p>
-            <h4 class="text-lg font-semibold">{{ role.role }}</h4>
-            <p class="text-xs uppercase tracking-wide opacity-70">{{ role.period }}</p>
-          </header>
-          <ul class="space-y-2 text-sm opacity-90">
-            {% for highlight in role.highlights %}
-              <li>• {{ highlight }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="ink" class="space-y-4" content=role_panel %}
-    {% endfor %}
-    {% capture early_panel %}
-      <div class="space-y-2">
-        <h4 class="text-sm uppercase tracking-wide opacity-70">{{ page_content.cv.experience.early_career.title }}</h4>
-        <ul class="text-sm opacity-80 space-y-1">
-          {% for role in page_content.cv.experience.early_career.roles %}
-            <li>• {{ role }}</li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endcapture %}
-    {% include panel.html tone="outline" class="space-y-2" content=early_panel %}
-  </div>
-{% endcapture %}
-
-{% capture cv_skills %}
-  <div class="grid md:grid-cols-2 gap-6">
-    {% capture skills_panel %}
-      <div class="space-y-3">
-        <h3 class="text-xl font-semibold">{{ page_content.cv.skills.title }}</h3>
-        <ul class="space-y-3 text-sm opacity-90">
-          {% for skill in page_content.cv.skills.categories %}
-            <li>
-              <span class="block font-semibold text-brandblack dark:text-white">{{ skill.name }}</span>
-              <span>{{ skill.detail }}</span>
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endcapture %}
-    {% include panel.html tone="ink" class="space-y-3" content=skills_panel %}
-
-    {% capture education_panel %}
-      <div class="space-y-3">
-        <h3 class="text-xl font-semibold">{{ page_content.cv.education.title }}</h3>
-        <p class="text-sm opacity-90">{{ page_content.cv.education.detail }}</p>
-      </div>
-    {% endcapture %}
-    {% include panel.html tone="frost" class="space-y-3" content=education_panel %}
-  </div>
-{% endcapture %}
-
-{% capture cv_section %}
-  <div class="space-y-12">
-    {{ cv_intro }}
-    <div class="grid lg:grid-cols-[1.6fr,1fr] gap-8">
-      {{ cv_roles }}
-      {{ cv_skills }}
-    </div>
-  </div>
-{% endcapture %}
-{% include section.html tone="blue" content=cv_section %}
+{% include section.html tone="plain" content=about_profile %}

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -5,7 +5,7 @@
   "display": "standalone",
   "background_color": "#0B0B0C",
   "theme_color": "#0B0B0C",
-  "description": "Independent analytics consultancy led by James Pearson delivering data platforms, experimentation, and forecasting.",
+  "description": "Independent analytics consultancy delivering data platforms, experimentation, and forecasting.",
   "icons": [
     {
       "src": "/assets/og-image.png",

--- a/contact/index.md
+++ b/contact/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Contact"
-description: "Start a conversation with James Pearson about analytics, experimentation, or forecasting engagements."
+description: "Start a conversation with Etterby Analytics about analytics, experimentation, or forecasting engagements."
 ---
 {% capture contact_intro %}
   <div class="max-w-2xl space-y-3">
@@ -39,9 +39,9 @@ description: "Start a conversation with James Pearson about analytics, experimen
       <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div class="space-y-1">
           <p class="font-medium text-brandblack/90 dark:text-white/90">Connect on LinkedIn</p>
-          <p class="text-sm text-brandblack/60 dark:text-white/60">Stay up to date with analytics insights and message James directly.</p>
+          <p class="text-sm text-brandblack/60 dark:text-white/60">Stay up to date with analytics insights and contact the Etterby Analytics team.</p>
         </div>
-        <a href="https://www.linkedin.com/in/james-pearson-etterby" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-brandblack/20 text-brandblack/80 hover:text-brandblue dark:border-white/20 dark:text-white/80 dark:hover:text-white transition" target="_blank" rel="noopener">
+        <a href="https://www.linkedin.com/company/etterby-analytics/" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-brandblack/20 text-brandblack/80 hover:text-brandblue dark:border-white/20 dark:text-white/80 dark:hover:text-white transition" target="_blank" rel="noopener">
           <span>View profile</span>
         </a>
       </div>

--- a/index.md
+++ b/index.md
@@ -8,22 +8,8 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
   <div class="space-y-8">
     <h1 class="text-5xl md:text-6xl font-semibold leading-tight">Analytics that drive outcomes.</h1>
     <p class="text-lg max-w-2xl">
-      I run a Carlisle analytics consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
+      Etterby Analytics is a Carlisle-based consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
-    <div class="flex flex-wrap gap-3 text-sm md:text-base text-brandblack/80 dark:text-white/80">
-      <div class="px-4 py-2 rounded-xl border border-brandblack/10 bg-brandblack/5 dark:border-white/10 dark:bg-white/5">
-        <span class="block font-semibold text-brandblack dark:text-white">Fraud cut 10% → 0.6%</span>
-        <span class="block text-xs md:text-sm text-brandblack/70 dark:text-white/70">Marketplace (EU) trust &amp; safety</span>
-      </div>
-      <div class="px-4 py-2 rounded-xl border border-brandblack/10 bg-brandblack/5 dark:border-white/10 dark:bg-white/5">
-        <span class="block font-semibold text-brandblack dark:text-white">+10% daily revenue uplift</span>
-        <span class="block text-xs md:text-sm text-brandblack/70 dark:text-white/70">Xcelirate pricing science</span>
-      </div>
-      <div class="px-4 py-2 rounded-xl border border-brandblack/10 bg-brandblack/5 dark:border-white/10 dark:bg-white/5">
-        <span class="block font-semibold text-brandblack dark:text-white">Self-serve usage tripled</span>
-        <span class="block text-xs md:text-sm text-brandblack/70 dark:text-white/70">Series C SaaS metrics layer</span>
-      </div>
-    </div>
     <div class="flex flex-wrap gap-4">
       <a href="/contact/" class="px-5 py-3 bg-brandblue text-white rounded-xl hover:bg-brandblue/90 transition">Book a call</a>
       <a href="/services/" class="px-5 py-3 border border-brandblack/30 dark:border-white/30 rounded-xl hover:border-brandblue/60 transition">View services</a>

--- a/insights/index.html
+++ b/insights/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Insights"
-description: "Experimentation, pricing, and analytics leadership lessons from James Pearson's consulting engagements."
+description: "Experimentation, pricing, and analytics leadership lessons from Etterby Analytics engagements."
 ---
 {% assign page_content = site.data.insights_page %}
 {% assign posts = site.posts %}

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -7,8 +7,8 @@ description: "How Etterby Analytics handles personal data submitted through the 
   <div class="space-y-4">
     <h1 class="text-3xl font-semibold">Privacy Policy</h1>
     <p class="opacity-90">Etterby Analytics collects personal data only when you submit the contact form or email <a class="underline" href="mailto:hello@etterby.com">hello@etterby.com</a>. Typical fields include your name, work email, company, and project context.</p>
-    <p class="opacity-90">The information is used exclusively to respond to your enquiry, qualify the engagement, and maintain a record of conversations. Data is stored securely in email and CRM tooling with access limited to James Pearson.</p>
-    <p class="opacity-90">We do not sell, rent, or share your personal data with third parties. If we agree to collaborate using shared systems (e.g. Slack, project management, analytics platforms) we will use your company-provided access controls.</p>
+    <p class="opacity-90">The information is used exclusively to respond to your enquiry, qualify the engagement, and maintain a record of conversations. Data is stored securely in email and CRM tooling with access limited to the Etterby Analytics leadership team.</p>
+    <p class="opacity-90">Etterby Analytics does not sell, rent, or share your personal data with third parties. If collaboration requires shared systems (e.g. Slack, project management, analytics platforms) the consultancy will use your company-provided access controls.</p>
     <p class="opacity-90">You can request updates or deletion of your information at any time by emailing <a class="underline" href="mailto:hello@etterby.com">hello@etterby.com</a>. This policy will evolve as the services and tooling change.</p>
   </div>
 {% endcapture %}

--- a/services/index.html
+++ b/services/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Services"
-description: "Consultancy engagements covering data platforms, analytics, experimentation, and forecasting led by James Pearson."
+description: "Consultancy engagements covering data platforms, analytics, experimentation, and forecasting delivered by Etterby Analytics."
 ---
 {% assign page_content = site.data.services_page %}
 {% assign services = site.services | sort: 'position' %}
@@ -12,71 +12,6 @@ description: "Consultancy engagements covering data platforms, analytics, experi
     {% for paragraph in page_content.hero.description %}
       <p class="opacity-90">{{ paragraph }}</p>
     {% endfor %}
-  </div>
-{% endcapture %}
-
-{% capture services_snapshot %}
-  <div class="space-y-6">
-    <div class="space-y-2">
-      <h2 class="text-xl font-semibold">Service snapshot</h2>
-      <p class="text-sm opacity-80">Match each engagement to the situation, delivery cadence, and outcome it is designed to deliver.</p>
-    </div>
-    <div class="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
-      {% for service in services %}
-        {% assign snapshot_use_case = "" %}
-        {% assign snapshot_timeline = "" %}
-        {% assign snapshot_outcome = "" %}
-        {% case service.title %}
-          {% when "Data Platforms & Reliability" %}
-            {% assign snapshot_use_case = "Scaling teams that need resilient ELT, governed models, and trustworthy metrics." %}
-            {% assign snapshot_timeline = "Readiness audit → modular dbt rollout → observability with shared SLAs." %}
-            {% assign snapshot_outcome = "Self-healing platform with visibility into freshness, lineage, and quality." %}
-          {% when "Tagging & Digital Analytics Foundations" %}
-            {% assign snapshot_use_case = "Marketing and product leaders stabilising GA4, consent, and cross-journey tracking." %}
-            {% assign snapshot_timeline = "Instrumentation audit → journey mapping → prioritised GTM backlog and owners." %}
-            {% assign snapshot_outcome = "Robust tagging and consent data powering confident campaign optimisation." %}
-          {% when "Analytics, BI & Enablement" %}
-            {% assign snapshot_use_case = "Organisations aligning KPI definitions and enabling teams with governed semantic layers." %}
-            {% assign snapshot_timeline = "Decision mapping → semantic layer design → high-impact dashboards and training." %}
-            {% assign snapshot_outcome = "Shared metrics and adopted analytics that replace ad-hoc requests." %}
-          {% when "Self-Service Dashboards & Embedded Analytics" %}
-            {% assign snapshot_use_case = "Operators needing daily rituals and embedded analytics that answer follow-up questions." %}
-            {% assign snapshot_timeline = "Stakeholder interviews → persona prioritisation → modelling and performance tuning." %}
-            {% assign snapshot_outcome = "Executive and embedded dashboards with clear ownership and enablement assets." %}
-          {% when "Experimentation, Forecasting & Applied ML" %}
-            {% assign snapshot_use_case = "Teams taking decisions with production ML, forecasting, or experiment programmes tied to KPIs." %}
-            {% assign snapshot_timeline = "Decision framing → data and test audit → phased delivery balancing exploration and enablement." %}
-            {% assign snapshot_outcome = "Production models and automated read-outs with playbooks for monitoring and retraining." %}
-          {% when "Revenue & Lifecycle Intelligence" %}
-            {% assign snapshot_use_case = "Pricing, retention, and lifecycle motions aiming for measurable P&L impact." %}
-            {% assign snapshot_timeline = "Revenue motion discovery → historic test audit → co-created roadmap across modelling & comms." %}
-            {% assign snapshot_outcome = "Revenue-shaping recommendations with aligned forecasts and executive storytelling." %}
-        {% endcase %}
-        {% capture snapshot_item %}
-          <div class="space-y-3">
-            <div class="space-y-1">
-              <p class="text-xs uppercase tracking-wide opacity-70">{{ service.tagline }}</p>
-              <h3 class="font-semibold text-base"><a href="{{ service.url }}">{{ service.title }}</a></h3>
-            </div>
-            <ul class="space-y-2 text-sm opacity-90">
-              <li>
-                <p class="text-xs uppercase tracking-wide opacity-70">Ideal use case</p>
-                <p>{{ snapshot_use_case }}</p>
-              </li>
-              <li>
-                <p class="text-xs uppercase tracking-wide opacity-70">Typical timeline</p>
-                <p>{{ snapshot_timeline }}</p>
-              </li>
-              <li>
-                <p class="text-xs uppercase tracking-wide opacity-70">Headline outcome</p>
-                <p>{{ snapshot_outcome }}</p>
-              </li>
-            </ul>
-          </div>
-        {% endcapture %}
-        {% include panel.html tone="ink" padding="p-5" content=snapshot_item %}
-      {% endfor %}
-    </div>
   </div>
 {% endcapture %}
 
@@ -97,9 +32,6 @@ description: "Consultancy engagements covering data platforms, analytics, experi
               </ul>
             {% endif %}
           </header>
-          <div class="prose prose-neutral dark:prose-invert max-w-none text-sm">
-            {{ service.content | markdownify }}
-          </div>
           <a href="{{ service.url }}" class="text-sm text-brandblue mt-auto">View service →</a>
         </div>
       {% endcapture %}
@@ -111,7 +43,6 @@ description: "Consultancy engagements covering data platforms, analytics, experi
 {% capture services_section %}
   <div class="space-y-10">
     {{ services_intro }}
-    {% include section.html tone="frost" padding="p-0" content=services_snapshot %}
     {{ services_cards }}
   </div>
 {% endcapture %}

--- a/terms/index.md
+++ b/terms/index.md
@@ -7,7 +7,7 @@ description: "Website terms for Etterby Analytics covering use of content, engag
   <div class="space-y-6">
     <div class="space-y-3">
       <h1 class="text-3xl font-semibold">Website Terms</h1>
-      <p class="opacity-90">Etterby Analytics Ltd (“we”, “us”) operates this site to share information about consultancy services delivered by James Pearson. By using the site you agree to these terms. If you do not agree, please discontinue use.</p>
+      <p class="opacity-90">Etterby Analytics Ltd operates this site to share information about consultancy services delivered by the Etterby Analytics team. By using the site you agree to these terms. If you do not agree, please discontinue use.</p>
     </div>
 
     <div class="space-y-3">
@@ -17,27 +17,27 @@ description: "Website terms for Etterby Analytics covering use of content, engag
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Engagements and proposals</h2>
-      <p class="opacity-90">Any proposal, statement of work, or master services agreement issued by Etterby Analytics supersedes the general information on this site. Fees, deliverables, and timelines are confirmed in writing for each engagement. We reserve the right to decline projects that present conflicts of interest or exceed available capacity.</p>
+      <p class="opacity-90">Any proposal, statement of work, or master services agreement issued by Etterby Analytics supersedes the general information on this site. Fees, deliverables, and timelines are confirmed in writing for each engagement. The consultancy reserves the right to decline projects that present conflicts of interest or exceed available capacity.</p>
     </div>
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Client responsibilities</h2>
-      <p class="opacity-90">Clients remain responsible for providing timely access to data, systems, and stakeholders required to complete the work. You are also accountable for ensuring you have the rights to share data with us and for acting on the recommendations delivered.</p>
+      <p class="opacity-90">Clients remain responsible for providing timely access to data, systems, and stakeholders required to complete the work. Each client is also accountable for ensuring they have the rights to share data with Etterby Analytics and for acting on the recommendations delivered.</p>
     </div>
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Confidentiality & data protection</h2>
-      <p class="opacity-90">We treat all client materials as confidential and use them solely for the agreed engagement. Mutual non-disclosure agreements can be executed on request. Personal data is handled in line with our <a class="underline" href="/privacy/">Privacy Policy</a>.</p>
+      <p class="opacity-90">Etterby Analytics treats all client materials as confidential and uses them solely for the agreed engagement. Mutual non-disclosure agreements can be executed on request. Personal data is handled in line with the <a class="underline" href="/privacy/">Privacy Policy</a>.</p>
     </div>
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Liability</h2>
-      <p class="opacity-90">To the fullest extent permitted by law, we exclude liability for indirect, special, or consequential losses arising from use of this site. Direct losses arising from paid engagements are limited to the fees paid for the relevant services unless a separate contract states otherwise.</p>
+      <p class="opacity-90">To the fullest extent permitted by law, Etterby Analytics excludes liability for indirect, special, or consequential losses arising from use of this site. Direct losses arising from paid engagements are limited to the fees paid for the relevant services unless a separate contract states otherwise.</p>
     </div>
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Third-party links</h2>
-      <p class="opacity-90">Links to external sites are provided for convenience only. We do not endorse or accept responsibility for third-party content or practices.</p>
+      <p class="opacity-90">Links to external sites are provided for convenience only. Etterby Analytics does not endorse or accept responsibility for third-party content or practices.</p>
     </div>
 
     <div class="space-y-3">

--- a/work/index.html
+++ b/work/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Work"
-description: "Case studies featuring fraud reduction, revenue optimisation, and analytics enablement delivered by James Pearson."
+description: "Case studies featuring fraud reduction, revenue optimisation, and analytics enablement delivered by Etterby Analytics."
 ---
 {% assign page_content = site.data.work_page %}
 {% assign work_items = site.work | sort: 'position' %}


### PR DESCRIPTION
## Summary
- default the theme to light mode and update the toggle initialisation scripts
- adjust the homepage hero by removing the outcome statistic boxes and rewriting copy in the third person
- rewrite marketing, about, services, and insights content to consistently use third-person language, remove the personal name, and streamline the services overview
