### PR TITLE
Refine header call-to-action and theme toggle

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,4 +1,3 @@
-
 - title: Services
   url: /services/
 - title: Work
@@ -7,5 +6,3 @@
   url: /about/
 - title: Insights
   url: /insights/
-- title: Contact
-  url: /contact/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,16 +6,20 @@
         <span class="font-semibold tracking-tight text-lg text-brandblack/90 dark:text-white/90 group-hover:text-brandblack dark:group-hover:text-white transition">Etterby <span class="text-brandblue">Analytics</span></span>
       </a>
       <button id="navToggle" class="md:hidden flex items-center gap-2 border border-brandblack/20 dark:border-white/20 rounded-lg px-3 py-2 text-sm text-brandblack/80 dark:text-white/80 transition" aria-expanded="false" aria-controls="mobileNav">Menu</button>
-      <nav id="mainNav" class="hidden md:flex items-center gap-6 text-sm text-brandblack/70 dark:text-white/70">
-        {% for item in site.data.nav %}
-          <a href="{{ item.url }}" class="hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
-        {% endfor %}
-        <button type="button" class="hidden md:inline-flex items-center gap-2 rounded-lg border border-brandblack/20 dark:border-white/20 px-4 py-2 text-sm font-medium text-brandblack/80 dark:text-white/80 transition hover:border-brandblue/60 hover:text-brandblue dark:hover:text-brandblue" data-theme-toggle>
-          <span class="inline-flex h-2 w-2 rounded-full bg-brandblack dark:bg-white"></span>
-          <span data-theme-toggle-label>Dark mode</span>
-        </button>
-        <a href="https://www.linkedin.com/company/etterby-analytics/" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
-        <a href="/contact/" class="inline-flex items-center justify-center px-4 py-2 rounded-lg border border-brandblue/60 text-brandblack dark:text-white hover:bg-brandblue hover:border-brandblue hover:text-white transition">Work together</a>
+      <nav id="mainNav" class="hidden md:flex flex-1 items-center justify-end gap-8 text-sm text-brandblack/70 dark:text-white/70">
+        <div class="flex items-center gap-6">
+          {% for item in site.data.nav %}
+            <a href="{{ item.url }}" class="hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
+          {% endfor %}
+          <a href="https://www.linkedin.com/company/etterby-analytics/" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
+        </div>
+        <div class="flex items-center gap-4">
+          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact us</a>
+          <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-brandblack/20 text-brandblack/70 transition hover:border-brandblue/60 hover:text-brandblue dark:border-white/20 dark:text-white/70 dark:hover:border-brandblue/60 dark:hover:text-brandblue" data-theme-toggle aria-label="Toggle theme">
+            <span class="sr-only" data-theme-toggle-label>Dark mode</span>
+            <span class="inline-flex h-3 w-3 rounded-full bg-brandblack transition-colors dark:bg-white"></span>
+          </button>
+        </div>
       </nav>
     </div>
   </div>
@@ -24,12 +28,12 @@
       {% for item in site.data.nav %}
         <a href="{{ item.url }}" class="py-1 hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
       {% endfor %}
-      <button type="button" class="mt-2 inline-flex items-center justify-center gap-2 rounded-lg border border-brandblack/15 dark:border-white/20 px-4 py-2 text-sm font-medium text-brandblack/80 dark:text-white/80 transition hover:border-brandblue/60 hover:text-brandblue dark:hover:text-brandblue" data-theme-toggle>
-        <span class="inline-flex h-2 w-2 rounded-full bg-brandblack dark:bg-white"></span>
-        <span data-theme-toggle-label>Dark mode</span>
-      </button>
       <a href="https://www.linkedin.com/company/etterby-analytics/" class="py-1 hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
-      <a href="/contact/" class="mt-2 inline-flex items-center justify-center px-4 py-2 rounded-lg bg-brandblue text-white">Work together</a>
+      <a href="/contact/" class="mt-1 inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact us</a>
+      <button type="button" class="inline-flex h-10 w-10 items-center justify-center self-end rounded-full border border-brandblack/15 text-brandblack/70 transition hover:border-brandblue/60 hover:text-brandblue dark:border-white/20 dark:text-white/70 dark:hover:border-brandblue/60 dark:hover:text-brandblue" data-theme-toggle aria-label="Toggle theme">
+        <span class="sr-only" data-theme-toggle-label>Dark mode</span>
+        <span class="inline-flex h-3 w-3 rounded-full bg-brandblack transition-colors dark:bg-white"></span>
+      </button>
     </div>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- consolidate the header CTA into a single "Contact us" button and remove the duplicate contact nav item
- reposition and restyle the theme toggle to sit at the end of the header for clearer hierarchy
- mirror the CTA and theme toggle improvements in the mobile navigation