### PR TITLE
Fix front matter formatting on terms page

### DIFF
--- a/terms/index.md
+++ b/terms/index.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Terms & Conditions"
 description: "Website terms for Etterby Analytics covering use of content, engagements, and limitations of liability."


### PR DESCRIPTION
## Summary
- remove the leading blank line in the terms page so the front matter renders correctly and no longer shows raw metadata on the page