### PR TITLE
Remove insight category grid

### DIFF
--- a/insights/index.html
+++ b/insights/index.html
@@ -16,21 +16,6 @@ description: "Experimentation, pricing, and analytics leadership lessons from Et
 {% endcapture %}
 {% include section.html tone="plain" padding="py-16" content=insights_hero %}
 
-{% capture category_grid %}
-  <div class="grid md:grid-cols-3 gap-6">
-    {% for category in page_content.categories.items %}
-      {% capture category_panel %}
-        <div class="space-y-2">
-          <h2 class="text-lg font-semibold">{{ category.name }}</h2>
-          <p class="text-sm opacity-80">{{ category.detail }}</p>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="frost" class="space-y-2" content=category_panel %}
-    {% endfor %}
-  </div>
-{% endcapture %}
-{% include section.html tone="frost" padding="py-16" content=category_grid %}
-
 {% capture articles_section %}
   <div class="space-y-6">
     <h2 class="text-2xl font-semibold">Latest articles</h2>


### PR DESCRIPTION
## Summary
- remove the category grid section from the Insights page so the layout focuses on Latest articles
