### PR TITLE
Align CTA label and adjust hero secondary link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
           <a href="https://www.linkedin.com/company/etterby-analytics/" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
         </div>
         <div class="flex items-center gap-4">
-          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact us</a>
+          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
           <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-brandblack/20 text-brandblack/70 transition hover:border-brandblue/60 hover:text-brandblue dark:border-white/20 dark:text-white/70 dark:hover:border-brandblue/60 dark:hover:text-brandblue" data-theme-toggle aria-label="Toggle theme">
             <span class="sr-only" data-theme-toggle-label>Dark mode</span>
             <span class="inline-flex h-3 w-3 rounded-full bg-brandblack transition-colors dark:bg-white"></span>
@@ -29,7 +29,7 @@
         <a href="{{ item.url }}" class="py-1 hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
       {% endfor %}
       <a href="https://www.linkedin.com/company/etterby-analytics/" class="py-1 hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
-      <a href="/contact/" class="mt-1 inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact us</a>
+      <a href="/contact/" class="mt-1 inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
       <button type="button" class="inline-flex h-10 w-10 items-center justify-center self-end rounded-full border border-brandblack/15 text-brandblack/70 transition hover:border-brandblue/60 hover:text-brandblue dark:border-white/20 dark:text-white/70 dark:hover:border-brandblue/60 dark:hover:text-brandblue" data-theme-toggle aria-label="Toggle theme">
         <span class="sr-only" data-theme-toggle-label>Dark mode</span>
         <span class="inline-flex h-3 w-3 rounded-full bg-brandblack transition-colors dark:bg-white"></span>

--- a/index.md
+++ b/index.md
@@ -10,9 +10,9 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
     <p class="text-lg max-w-2xl">
       Etterby Analytics is a Carlisle-based consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
-    <div class="flex flex-wrap gap-4">
+    <div class="flex flex-wrap gap-4 items-center">
       <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
-      <a href="/services/" class="inline-flex items-center justify-center rounded-full border border-brandblack/30 px-6 py-3 text-base font-semibold text-brandblack/80 transition hover:border-brandblue/60 hover:text-brandblue focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40 dark:border-white/30 dark:text-white/80">View services</a>
+      <a href="/services/" class="text-base font-medium text-brandblack/70 transition hover:text-brandblue focus-visible:underline dark:text-white/70">View services</a>
     </div>
   </div>
 {% endcapture %}


### PR DESCRIPTION
## Summary
- align the primary call-to-action text to "Book a call" across the hero, header, and mobile navigation
- soften the hero's secondary services link styling so it reads as a supporting text link