### PR TITLE
Rework work page hero and remove sidebar

### DIFF
--- a/work/index.html
+++ b/work/index.html
@@ -5,95 +5,65 @@ description: "Case studies featuring fraud reduction, revenue optimisation, and 
 ---
 {% assign page_content = site.data.work_page %}
 {% assign work_items = site.work | sort: 'position' %}
+{% assign process_titles = page_content.process.steps | map: 'title' %}
 {% capture work_hero %}
-  <div class="max-w-3xl space-y-4">
-    <p class="text-xs uppercase tracking-wide opacity-70">{{ page_content.hero.eyebrow }}</p>
-    <h1 class="text-3xl md:text-4xl font-semibold">{{ page_content.hero.title }}</h1>
-    {% for paragraph in page_content.hero.description %}
-      <p class="opacity-90">{{ paragraph }}</p>
-    {% endfor %}
+  <div class="max-w-4xl space-y-6">
+    <div class="space-y-4">
+      <p class="text-xs uppercase tracking-wide opacity-70">{{ page_content.hero.eyebrow }}</p>
+      <h1 class="text-3xl md:text-4xl font-semibold">{{ page_content.hero.title }}</h1>
+      {% for paragraph in page_content.hero.description %}
+        <p class="opacity-90">{{ paragraph }}</p>
+      {% endfor %}
+    </div>
+    <div class="flex flex-wrap gap-3 text-sm">
+      {% for stat in page_content.stats %}
+        <span class="inline-flex items-baseline gap-2 rounded-full bg-white/10 px-4 py-2">
+          <span class="font-semibold text-base tracking-normal">{{ stat.value }}</span>
+          <span class="text-xs uppercase tracking-wide opacity-70">{{ stat.label }}</span>
+        </span>
+      {% endfor %}
+    </div>
+    <p class="text-sm opacity-80">
+      <strong>{{ page_content.filters.title }}:</strong> {{ page_content.filters.items | join: ', ' }}.
+      <strong>{{ page_content.process.title }}:</strong> {{ process_titles | join: ' → ' }}.
+    </p>
   </div>
 {% endcapture %}
 {% include section.html tone="plain" padding="py-16" content=work_hero %}
 
 {% capture work_grid %}
-  <div class="grid md:grid-cols-[2fr,1fr] gap-8">
-    <div class="space-y-6">
-      {% for item in work_items %}
-        {% capture case_panel %}
-          <div class="space-y-4">
-            <header class="space-y-2">
-              <p class="text-xs uppercase tracking-wide opacity-70 flex gap-3 flex-wrap">
-                <span>{{ item.industry }}</span>
-                {% if item.services %}
-                  <span class="opacity-60">·</span>
-                  <span>{{ item.services | join: ', ' }}</span>
-                {% endif %}
-              </p>
-              <h2 class="text-2xl font-semibold"><a href="{{ item.url }}">{{ item.title }}</a></h2>
-              <p class="text-sm opacity-90">{{ item.summary }}</p>
-            </header>
-            <div class="text-sm opacity-80 space-y-2">
-              {% if item.results %}
-                <h3 class="font-semibold text-xs uppercase tracking-wide opacity-70">Impact</h3>
-                <ul class="space-y-1">
-                  {% for result in item.results %}
-                    <li>• {{ result }}</li>
-                  {% endfor %}
-                </ul>
+  <div class="space-y-6">
+    {% for item in work_items %}
+      {% capture case_panel %}
+        <div class="space-y-4">
+          <header class="space-y-2">
+            <p class="text-xs uppercase tracking-wide opacity-70 flex gap-3 flex-wrap">
+              <span>{{ item.industry }}</span>
+              {% if item.services %}
+                <span class="opacity-60">·</span>
+                <span>{{ item.services | join: ', ' }}</span>
               {% endif %}
-              {% if item.duration %}
-                <p class="text-xs uppercase tracking-wide opacity-60">Engagement length: {{ item.duration }}</p>
-              {% endif %}
-            </div>
+            </p>
+            <h2 class="text-2xl font-semibold"><a href="{{ item.url }}">{{ item.title }}</a></h2>
+            <p class="text-sm opacity-90">{{ item.summary }}</p>
+          </header>
+          <div class="text-sm opacity-80 space-y-2">
+            {% if item.results %}
+              <h3 class="font-semibold text-xs uppercase tracking-wide opacity-70">Impact</h3>
+              <ul class="space-y-1">
+                {% for result in item.results %}
+                  <li>• {{ result }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            {% if item.duration %}
+              <p class="text-xs uppercase tracking-wide opacity-60">Engagement length: {{ item.duration }}</p>
+            {% endif %}
           </div>
-        {% endcapture %}
-        {% include panel.html tone="ink" class="space-y-4" content=case_panel %}
-      {% endfor %}
-    </div>
-    <aside class="space-y-6">
-      {% capture filters_panel %}
-        <div class="space-y-3">
-          <h2 class="text-lg font-semibold">{{ page_content.filters.title }}</h2>
-          <ul class="space-y-2 text-sm opacity-80">
-            {% for filter in page_content.filters.items %}
-              <li>• {{ filter }}</li>
-            {% endfor %}
-          </ul>
         </div>
       {% endcapture %}
-      {% include panel.html tone="frost" class="space-y-3" content=filters_panel %}
-
-      {% capture stats_panel %}
-        <div class="space-y-4">
-          <h2 class="text-lg font-semibold">Delivery snapshot</h2>
-          <dl class="space-y-3">
-            {% for stat in page_content.stats %}
-              <div>
-                <dt class="text-xs uppercase tracking-wide opacity-60">{{ stat.label }}</dt>
-                <dd class="text-lg font-semibold">{{ stat.value }}</dd>
-              </div>
-            {% endfor %}
-          </dl>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="ink" class="space-y-4" content=stats_panel %}
-
-      {% capture process_panel %}
-        <div class="space-y-4">
-          <h2 class="text-lg font-semibold">{{ page_content.process.title }}</h2>
-          <ol class="space-y-3 text-sm opacity-80">
-            {% for step in page_content.process.steps %}
-              <li>
-                <span class="block font-semibold text-brandblack dark:text-white">{{ step.title }}</span>
-                <span>{{ step.detail }}</span>
-              </li>
-            {% endfor %}
-          </ol>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="outline" class="space-y-4" content=process_panel %}
-    </aside>
+      {% include panel.html tone="ink" class="space-y-4" content=case_panel %}
+    {% endfor %}
   </div>
 {% endcapture %}
 {% include section.html tone="blue" padding="py-16" content=work_grid %}


### PR DESCRIPTION
## Summary
- elevate key delivery stats as badges beneath the work page hero copy
- fold filter and process details into a single paragraph to declutter supporting content
- remove the sidebar panels so the case grid becomes the primary layout focus