### PR TITLE
Replace “Book a call” CTA with “Contact”

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
           <a href="https://www.linkedin.com/company/etterby-analytics/" class="hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
         </div>
         <div class="flex items-center gap-4">
-          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
+          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact</a>
           <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-brandblack/20 text-brandblack/70 transition hover:border-brandblue/60 hover:text-brandblue dark:border-white/20 dark:text-white/70 dark:hover:border-brandblue/60 dark:hover:text-brandblue" data-theme-toggle aria-label="Toggle theme">
             <span class="sr-only" data-theme-toggle-label>Dark mode</span>
             <span class="inline-flex h-3 w-3 rounded-full bg-brandblack transition-colors dark:bg-white"></span>
@@ -29,7 +29,7 @@
         <a href="{{ item.url }}" class="py-1 hover:text-brandblack dark:hover:text-white transition">{{ item.title }}</a>
       {% endfor %}
       <a href="https://www.linkedin.com/company/etterby-analytics/" class="py-1 hover:text-brandblack dark:hover:text-white transition" target="_blank" rel="noopener">LinkedIn</a>
-      <a href="/contact/" class="mt-1 inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
+      <a href="/contact/" class="mt-1 inline-flex items-center justify-center rounded-full bg-brandblue px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact</a>
       <button type="button" class="inline-flex h-10 w-10 items-center justify-center self-end rounded-full border border-brandblack/15 text-brandblack/70 transition hover:border-brandblue/60 hover:text-brandblue dark:border-white/20 dark:text-white/70 dark:hover:border-brandblue/60 dark:hover:text-brandblue" data-theme-toggle aria-label="Toggle theme">
         <span class="sr-only" data-theme-toggle-label>Dark mode</span>
         <span class="inline-flex h-3 w-3 rounded-full bg-brandblack transition-colors dark:bg-white"></span>

--- a/_layouts/case.html
+++ b/_layouts/case.html
@@ -53,7 +53,7 @@ layout: default
         <div class="space-y-3">
           <h2 class="text-lg font-semibold">Plan your own engagement</h2>
           <p class="text-sm opacity-80">Let's align on the outcomes you need and the path to get there.</p>
-          <a href="/contact/" class="block rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-center text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
+          <a href="/contact/" class="block rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-center text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact</a>
         </div>
       {% endcapture %}
       {% include panel.html tone="solid" class="space-y-3" content=plan_panel %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,7 +52,7 @@ layout: default
         <div class="space-y-3">
           <h2 class="text-lg font-semibold">Talk through your own challenge</h2>
           <p class="text-sm text-brandblack/70 dark:text-white/70">Share the context behind your data and analytics goals and Etterby Analytics will map the fastest path to value.</p>
-          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
+          <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact</a>
         </div>
       {% endcapture %}
       {% include panel.html tone="solid" class="space-y-3" content=challenge_panel %}

--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -40,7 +40,7 @@ layout: default
 
       {% capture call_panel %}
         <div class="space-y-3">
-          <h2 class="text-lg font-semibold">Book a call</h2>
+          <h2 class="text-lg font-semibold">Contact</h2>
           <p class="text-sm opacity-80">Share your goals and Etterby Analytics will map the quickest route to value.</p>
           <a href="/contact/" class="block rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-center text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Discuss your project</a>
         </div>

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
       Etterby Analytics is a Carlisle-based consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
     <div class="flex flex-wrap gap-4 items-center">
-      <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Book a call</a>
+      <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact</a>
       <a href="/services/" class="text-base font-medium text-brandblack/70 transition hover:text-brandblue focus-visible:underline dark:text-white/70">View services</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- update navigation and CTA buttons to display "Contact" instead of "Book a call"
- align service layout heading with the new "Contact" terminology