### PR TITLE
Simplify About page narrative

### DIFF
--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -1,36 +1,42 @@
 hero:
   eyebrow: "About Etterby Analytics"
-  title: "Founder-led analytics with measurable outcomes"
+  title: "Founder-led analytics for teams that need momentum"
   description:
-    - "Etterby Analytics is an independent consultancy based in Carlisle, partnering with product and operations teams to make better commercial decisions with reliable data."
-    - "Engagements pair on-site work across Cumbria with remote collaboration for UK organisations and select global partners, focusing every project on tangible improvements to revenue, trust, or efficiency."
-profile:
-  title: "Founder-led delivery"
-  name: "Carlisle-based leadership"
-  bio:
-    - "Led by an embedded analytics founder with more than a decade delivering experimentation, forecasting, and BI programmes."
-    - "Hands-on across discovery, modelling, and enablement to make sure capability stays inside your organisation."
-    - "Trusted by marketplaces, SaaS scale-ups, and hospitality brands needing resilient data foundations and accountable outcomes."
-values:
-  title: "Principles that guide every engagement"
+    - "Etterby Analytics is a Carlisle-based consultancy partnering with founders, product leaders, and operators who need sharper decisions without adding headcount."
+    - "Every engagement is led by the founder, bringing 10+ years of experimentation, forecasting, and BI leadership directly into your roadmap so measurable progress shows up fast."
+narrative:
+  intro:
+    - "Founder-led companies like Basecamp and Stripe tell simple stories: why they exist, how they work, and the proof that it matters. Etterby follows the same playbook—focused on clarity, accountability, and outcomes from the very first working session."
+  sections:
+    - title: "Why Etterby exists"
+      body:
+        - "Too many analytics programmes stall because strategy and delivery are split across agencies, vendors, and internal teams. Etterby was created to be the senior partner who ships the work and stays present until results are in motion."
+    - title: "How the work happens"
+      body:
+        - "Each project begins with a working session to surface the decisions you need to make. From there, sprints deliver production-ready models, instrumentation, and enablement materials—not slide decks. The same person designs the solution, implements it, and equips your team to run it."
+    - title: "What you can expect"
+      body:
+        - "Expect transparent plans, weekly momentum, and clear metrics that show progress. Engagements scale from a few focused weeks to multi-quarter partnerships, always with a founder at the table instead of a rotating agency bench."
+pillars:
+  title: "Three pillars of every engagement"
   items:
-    - title: "Evidence over opinion"
-      detail: "Decisions start with quantified baselines, measurable targets, and transparent assumptions."
-    - title: "Ship to learn"
-      detail: "Deliver production-ready increments quickly so teams can react, iterate, and adopt."
-    - title: "Enable the organisation"
-      detail: "Pair delivery with playbooks, training, and governance so capability remains after handover."
-credentials:
-  title: "Selected outcomes"
-  items:
-    - "Reduced fraudulent users from 10% to 0.6% with precision of 97% for a global marketplace."
-    - "Delivered price optimisation models that lifted daily revenue by 10%."
-    - "Implemented ThoughtSpot for enterprise restaurant brands, driving self-serve analytics adoption."
-contact_cta:
-  label: "Book a working session"
+    - title: "Evidence-first decisions"
+      description: "Quantified baselines and measurable targets anchor every recommendation, replacing guesswork with confidence."
+    - title: "Momentum through delivery"
+      description: "Working software, dashboards, and playbooks ship continuously so your teams can act before the quarter ends."
+    - title: "Enablement that sticks"
+      description: "Internal teams leave with training, governance, and documentation that keeps capability in-house after handover."
+proof:
+  title: "Signals the approach works"
+  points:
+    - "Dropped fraudulent activity from 10% to 0.6% for a global marketplace while maintaining 97% precision."
+    - "Lifted daily revenue by 10% through pricing experimentation for a hospitality group."
+    - "Rolled out ThoughtSpot across enterprise restaurant brands, unlocking self-serve analytics adoption."
+founder_quote:
+  quote: "Clients don\'t need another deck—they need a senior partner who ships the work and leaves the team stronger than they arrived."
+  name: "Founder, Etterby Analytics"
+cta:
+  title: "Ready to build momentum?"
+  description: "Book a working session to map the decisions in front of you and the data needed to back them."
+  label: "Schedule a working session"
   url: "/contact/"
-story:
-  title: "A different kind of analytics partner"
-  paragraphs:
-    - "The consultancy was created to give growth teams senior analytics leadership without the overhead that comes with large agencies. Every engagement is delivered by the founder, not a rotating squad of juniors."
-    - "Competitors often prioritise headcount and billable hours. Etterby Analytics focuses on a smaller roster of clients, keeping execution close to decision-makers and sharing playbooks so internal teams stay confident after handover."

--- a/about/index.md
+++ b/about/index.md
@@ -4,84 +4,83 @@ title: "About"
 description: "Learn how Etterby Analytics operates, the founder-led principles behind the consultancy, and the outcomes delivered for product and operations teams."
 ---
 {% assign page_content = site.data.about_page %}
+
 {% capture about_hero %}
-  <div class="max-w-3xl space-y-4">
-    <p class="text-xs uppercase tracking-wide opacity-70">{{ page_content.hero.eyebrow }}</p>
-    <h1 class="text-3xl md:text-4xl font-semibold">{{ page_content.hero.title }}</h1>
+  <div class="max-w-3xl space-y-6 text-balance">
+    <p class="text-xs uppercase tracking-[0.2em] opacity-70">{{ page_content.hero.eyebrow }}</p>
+    <h1 class="text-3xl md:text-5xl font-semibold leading-tight">{{ page_content.hero.title }}</h1>
     {% for paragraph in page_content.hero.description %}
-      <p class="opacity-90">{{ paragraph }}</p>
+      <p class="text-base md:text-lg opacity-90">{{ paragraph }}</p>
     {% endfor %}
   </div>
 {% endcapture %}
-{% include section.html tone="plain" padding="py-16" content=about_hero %}
+{% include section.html tone="plain" padding="py-20" content=about_hero %}
 
-{% capture story_block %}
-  <div class="max-w-3xl space-y-4">
-    <h2 class="text-2xl font-semibold">{{ page_content.story.title }}</h2>
-    {% for paragraph in page_content.story.paragraphs %}
-      <p class="opacity-90">{{ paragraph }}</p>
+{% capture about_story %}
+  <div class="max-w-3xl space-y-8">
+    {% for paragraph in page_content.narrative.intro %}
+      <p class="text-base md:text-lg opacity-90">{{ paragraph }}</p>
     {% endfor %}
-  </div>
-{% endcapture %}
-{% include section.html tone="frost" padding="py-12" content=story_block %}
-
-{% capture about_profile %}
-  <div class="grid md:grid-cols-[2fr,1fr] gap-8 items-start">
-    <div class="space-y-6">
-      {% capture profile_panel %}
+    <div class="space-y-8">
+      {% for section in page_content.narrative.sections %}
         <div class="space-y-3">
-          <h2 class="text-2xl font-semibold">{{ page_content.profile.title }}</h2>
-          <p class="text-sm uppercase tracking-wide text-brandblack/70 dark:text-white/70">{{ page_content.profile.name }}</p>
-          <ul class="space-y-3 text-sm opacity-90">
-            {% for item in page_content.profile.bio %}
-              <li>• {{ item }}</li>
-            {% endfor %}
-          </ul>
+          <h2 class="text-xl md:text-2xl font-semibold">{{ section.title }}</h2>
+          {% for paragraph in section.body %}
+            <p class="opacity-80">{{ paragraph }}</p>
+          {% endfor %}
         </div>
-      {% endcapture %}
-      {% include panel.html tone="ink" class="space-y-4" content=profile_panel %}
-
-      {% capture values_panel %}
-        <div class="space-y-4">
-          <h2 class="text-2xl font-semibold">{{ page_content.values.title }}</h2>
-          <div class="grid md:grid-cols-2 gap-4">
-            {% for value in page_content.values.items %}
-              {% capture value_block %}
-                <div class="space-y-2">
-                  <h3 class="font-semibold">{{ value.title }}</h3>
-                  <p class="text-sm opacity-90">{{ value.detail }}</p>
-                </div>
-              {% endcapture %}
-              {% include panel.html tone="frost" padding="p-4" content=value_block %}
-            {% endfor %}
-          </div>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="frost" class="space-y-4" content=values_panel %}
+      {% endfor %}
     </div>
-
-    <aside class="space-y-6">
-      {% capture credentials_panel %}
-        <div class="space-y-3">
-          <h2 class="text-lg font-semibold">{{ page_content.credentials.title }}</h2>
-          <ul class="space-y-2 text-sm opacity-80">
-            {% for item in page_content.credentials.items %}
-              <li>• {{ item }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="frost" class="space-y-3" content=credentials_panel %}
-
-      {% capture contact_panel %}
-        <div class="space-y-3 text-center">
-          <h2 class="text-lg font-semibold">Ready to collaborate?</h2>
-          <p class="text-sm text-brandblack/70 dark:text-white/70">Discuss your analytics roadmap and the momentum Etterby Analytics can unlock.</p>
-          <a href="{{ page_content.contact_cta.url }}" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">{{ page_content.contact_cta.label }}</a>
-        </div>
-      {% endcapture %}
-      {% include panel.html tone="solid" class="space-y-3" content=contact_panel %}
-    </aside>
   </div>
 {% endcapture %}
-{% include section.html tone="plain" content=about_profile %}
+{% include section.html tone="frost" padding="py-16" content=about_story %}
+
+{% capture about_pillars %}
+  <div class="max-w-4xl space-y-6">
+    <h2 class="text-2xl font-semibold">{{ page_content.pillars.title }}</h2>
+    <div class="grid gap-6 md:grid-cols-3">
+      {% for pillar in page_content.pillars.items %}
+        {% capture pillar_block %}
+          <div class="space-y-3">
+            <h3 class="text-lg font-semibold">{{ pillar.title }}</h3>
+            <p class="text-sm md:text-base opacity-80">{{ pillar.description }}</p>
+          </div>
+        {% endcapture %}
+        {% include panel.html tone="frost" padding="p-6" content=pillar_block %}
+      {% endfor %}
+    </div>
+  </div>
+{% endcapture %}
+{% include section.html tone="plain" padding="py-16" content=about_pillars %}
+
+{% capture about_proof %}
+  <div class="max-w-3xl space-y-6">
+    <h2 class="text-2xl font-semibold">{{ page_content.proof.title }}</h2>
+    <ul class="space-y-4">
+      {% for point in page_content.proof.points %}
+        <li class="flex gap-3 text-sm md:text-base opacity-90">
+          <span class="mt-2 h-2 w-2 rounded-full bg-brandblue"></span>
+          <span>{{ point }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endcapture %}
+{% include section.html tone="ink" padding="py-16" content=about_proof %}
+
+{% capture about_quote %}
+  <figure class="mx-auto max-w-3xl space-y-4 text-center">
+    <blockquote class="text-xl md:text-2xl font-medium leading-relaxed">“{{ page_content.founder_quote.quote }}”</blockquote>
+    <figcaption class="text-xs uppercase tracking-[0.2em] text-brandblack/70 dark:text-white/70">{{ page_content.founder_quote.name }}</figcaption>
+  </figure>
+{% endcapture %}
+{% include section.html tone="plain" padding="py-14" content=about_quote %}
+
+{% capture about_cta %}
+  <div class="max-w-2xl space-y-4 text-center mx-auto">
+    <h2 class="text-2xl font-semibold">{{ page_content.cta.title }}</h2>
+    <p class="text-sm md:text-base opacity-80">{{ page_content.cta.description }}</p>
+    <a href="{{ page_content.cta.url }}" class="inline-flex items-center justify-center rounded-full bg-brandblue px-8 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">{{ page_content.cta.label }}</a>
+  </div>
+{% endcapture %}
+{% include section.html tone="frost" padding="py-16" content=about_cta %}


### PR DESCRIPTION
## Summary
- rebuild the About page layout into a concise single-column story that follows a founder-led narrative structure
- refresh about_page data to highlight origin, approach, proof points, and a streamlined call to action