### PR TITLE
Fix YAML quoting error in about page data

### DIFF
--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -33,7 +33,7 @@ proof:
     - "Lifted daily revenue by 10% through pricing experimentation for a hospitality group."
     - "Rolled out ThoughtSpot across enterprise restaurant brands, unlocking self-serve analytics adoption."
 founder_quote:
-  quote: "Clients don\'t need another deck—they need a senior partner who ships the work and leaves the team stronger than they arrived."
+  quote: "Clients don't need another deck—they need a senior partner who ships the work and leaves the team stronger than they arrived."
   name: "Founder, Etterby Analytics"
 cta:
   title: "Ready to build momentum?"


### PR DESCRIPTION
## Summary
- remove the incorrect backslash escape in the about page data file so YAML parses correctly