### PR TITLE
Configure GA4 tracking with production measurement ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Static site built with Jekyll for GitHub Pages.
 3. Set Custom Domain (`etterby.com`) and Enforce HTTPS
 4. DNS: `CNAME @` and `CNAME www` → `USERNAME.github.io`
 
+## Google Analytics (GA4)
+1. Visit <https://analytics.google.com> and sign in with your personal Google account. A free GA4 property is included in every account.
+2. Create a new property (or reuse an existing one) and follow the setup wizard until you reach the "Data streams" step. Select "Web" and enter the production URL (e.g. `https://etterby.com`).
+3. Copy the Measurement ID that begins with `G-` from the stream details.
+4. Update `_config.yml` and set `google_analytics.measurement_id` to the copied ID (the production site currently uses `G-8T9EL4DVTW`). When the site builds, the default layout automatically injects the Google tag snippet.
+
 ## Edit content
 - Homepage: `index.md`
 - Services: `_services/*.md`

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@ title: "Etterby Analytics"
 description: "Premium, minimal, outcomes-first analytics consulting. Pipelines, metrics, and ML that ship and stick."
 url: "https://etterby.com"  # set to https://etterby.com when live
 baseurl: ""  # set to /analytics only if using subpath
+google_analytics:
+  measurement_id: G-8T9EL4DVTW
 markdown: kramdown
 theme: null
 plugins: []

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,16 @@
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta property="og:image" content="/assets/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
+  {% if site.google_analytics.measurement_id %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics.measurement_id }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '{{ site.google_analytics.measurement_id }}');
+  </script>
+  {% endif %}
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- add a configurable Google Analytics (GA4) measurement ID to the site config and layout
- document how to retrieve a free GA4 property and enable tracking for the site
- configure the production GA4 measurement ID (G-8T9EL4DVTW) and align the injected snippet with the standard GA4 template