### PR TITLE
Refine SEO metadata for brand-first titles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,18 +3,28 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  {% assign site_brand = site.title | default: site.name %}
+  {% assign page_title = site_brand %}
+  {% if page.title %}
+    {% assign candidate_title = page.title | strip %}
+    {% if candidate_title != '' and candidate_title != site_brand %}
+      {% assign page_title = candidate_title | append: ' | ' | append: site_brand %}
+    {% endif %}
+  {% endif %}
+  <title>{{ page_title }}</title>
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
   <meta name="description" content="{{ page.description | default: site.description }}">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#F6F7F9" id="theme-color-meta">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="/assets/site.webmanifest">
   <link rel="apple-touch-icon" href="/assets/og-image.png">
-  <meta property="og:title" content="{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}">
+  <meta property="og:title" content="{{ page_title }}">
+  <meta property="og:site_name" content="{{ site_brand }}">
   <meta property="og:description" content="{{ page.description | default: site.description }}">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-  <meta property="og:image" content="/assets/og-image.png">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
+  <meta property="og:image" content="{{ '/assets/og-image.png' | absolute_url }}">
   <meta name="twitter:card" content="summary_large_image">
   {% if site.google_analytics.measurement_id %}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics.measurement_id }}"></script>
@@ -50,6 +60,26 @@
         "postalCode": "{{ site.company.address.postal_code }}",
         "addressCountry": "{{ site.company.address.address_country }}"
       }
+    }
+  </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "itemListElement": [
+        {
+          "@type": "SiteNavigationElement",
+          "position": 1,
+          "name": "About",
+          "url": "{{ '/about/' | absolute_url }}"
+        },
+        {
+          "@type": "SiteNavigationElement",
+          "position": 2,
+          "name": "Contact",
+          "url": "{{ '/contact/' | absolute_url }}"
+        }
+      ]
     }
   </script>
   <script>


### PR DESCRIPTION
## Summary
- update the default layout to keep homepage titles brand-only while appending the brand for interior pages following SEO title best practices
- add canonical and Open Graph URL/image refinements so metadata stays consistent across the site
- publish JSON-LD navigation metadata that highlights About and Contact for sitelink eligibility