### PR TITLE
Update CTA styling and copy across pages

### DIFF
--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -38,5 +38,5 @@ founder_quote:
 cta:
   title: "Ready to build momentum?"
   description: "Book a working session to map the decisions in front of you and the data needed to back them."
-  label: "Schedule a working session"
+  label: "Contact"
   url: "/contact/"

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -16,5 +16,5 @@ insights:
   description: "Field-tested playbooks on experimentation, forecasting, and analytics leadership drawn from 11+ years in data roles."
   limit: 3
   view_all:
-    label: "See all insights"
+    label: "EXPORE ALL INSIGHTS"
     url: "/insights/"

--- a/_data/work_page.yml
+++ b/_data/work_page.yml
@@ -27,3 +27,8 @@ process:
       detail: "Deliver production-ready assets with testing, observability, and documentation."
     - title: "Adopt"
       detail: "Enable teams with playbooks, training, and handover support."
+cta:
+  title: "Ready to work together?"
+  description: "Tell Etterby Analytics about the outcomes you're aiming for and map the project that gets you there."
+  label: "Contact"
+  url: "/contact/"

--- a/index.md
+++ b/index.md
@@ -116,7 +116,7 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
       <h2 class="text-3xl font-semibold">{{ home_insights.title }}</h2>
       <p class="mt-2 opacity-80 max-w-2xl">{{ home_insights.description }}</p>
     </div>
-    <a href="{{ home_insights.view_all.url }}" class="text-sm uppercase tracking-wide opacity-80 hover:opacity-100">{{ home_insights.view_all.label }}</a>
+    <a href="{{ home_insights.view_all.url }}" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">{{ home_insights.view_all.label }}</a>
   </div>
 {% endcapture %}
 {% capture insights_grid %}

--- a/insights/index.html
+++ b/insights/index.html
@@ -43,7 +43,7 @@ description: "Experimentation, pricing, and analytics leadership lessons from Et
 {% include section.html tone="blue" padding="py-16" content=articles_section %}
 
 {% capture newsletter_panel %}
-  <div class="space-y-4">
+  <div class="space-y-4 text-center max-w-2xl mx-auto">
     <h2 class="text-2xl font-semibold">{{ page_content.newsletter.title }}</h2>
     <p class="opacity-80">{{ page_content.newsletter.body }}</p>
     <a href="{{ page_content.newsletter.cta_url }}" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">{{ page_content.newsletter.cta_label }}</a>

--- a/work/index.html
+++ b/work/index.html
@@ -67,3 +67,14 @@ description: "Case studies featuring fraud reduction, revenue optimisation, and 
   </div>
 {% endcapture %}
 {% include section.html tone="blue" padding="py-16" content=work_grid %}
+
+{% if page_content.cta %}
+  {% capture work_cta %}
+    <div class="max-w-2xl space-y-4 text-center mx-auto">
+      <h2 class="text-2xl font-semibold">{{ page_content.cta.title }}</h2>
+      <p class="text-sm md:text-base opacity-80">{{ page_content.cta.description }}</p>
+      <a href="{{ page_content.cta.url }}" class="inline-flex items-center justify-center rounded-full bg-brandblue px-8 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">{{ page_content.cta.label }}</a>
+    </div>
+  {% endcapture %}
+  {% include section.html tone="frost" padding="py-16" content=work_cta %}
+{% endif %}


### PR DESCRIPTION
## Summary
- restyle the homepage insights call-to-action to match other buttons and update its label
- switch the about page hero call-to-action to "Contact" and surface a matching section on the work page
- center the closing call-to-action on the insights page for improved alignment