### PR TITLE
Normalize copy hyphenation and adjust CTAs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 
 title: "Etterby Analytics"
-description: "Premium, minimal, outcomes-first analytics consulting. Pipelines, metrics, and ML that ship and stick."
+description: "Premium, minimal, outcomes first analytics consulting. Pipelines, metrics, and ML that ship and stick."
 url: "https://etterby.com"  # set to https://etterby.com when live
 baseurl: ""  # set to /analytics only if using subpath
 google_analytics:
@@ -47,9 +47,9 @@ company:
   same_as:
     - "https://www.linkedin.com/company/etterby-analytics/"
   address:
-    street_address: "Remote-first"
+    street_address: "Remote first"
     address_locality: "London"
     address_region: "England"
     postal_code: ""
     address_country: "GB"
-  founder: "Founder-led analytics team"
+  founder: "Founder led analytics team"

--- a/_data/about_page.yml
+++ b/_data/about_page.yml
@@ -1,39 +1,39 @@
 hero:
   eyebrow: "About Etterby Analytics"
-  title: "Founder-led analytics for teams that need momentum"
+  title: "Founder led analytics for teams that need momentum"
   description:
-    - "Etterby Analytics is a Carlisle-based consultancy partnering with founders, product leaders, and operators who need sharper decisions without adding headcount."
+    - "Etterby Analytics is a Carlisle based consultancy partnering with founders, product leaders, and operators who need sharper decisions without adding headcount."
     - "Every engagement is led by the founder, bringing 10+ years of experimentation, forecasting, and BI leadership directly into your roadmap so measurable progress shows up fast."
 narrative:
   intro:
-    - "Founder-led companies like Basecamp and Stripe tell simple stories: why they exist, how they work, and the proof that it matters. Etterby follows the same playbook—focused on clarity, accountability, and outcomes from the very first working session."
+    - "Founder led companies like Basecamp and Stripe tell simple stories: why they exist, how they work, and the proof that it matters. Etterby follows the same playbook—focused on clarity, accountability, and outcomes from the very first working session."
   sections:
     - title: "Why Etterby exists"
       body:
         - "Too many analytics programmes stall because strategy and delivery are split across agencies, vendors, and internal teams. Etterby was created to be the senior partner who ships the work and stays present until results are in motion."
     - title: "How the work happens"
       body:
-        - "Each project begins with a working session to surface the decisions you need to make. From there, sprints deliver production-ready models, instrumentation, and enablement materials—not slide decks. The same person designs the solution, implements it, and equips your team to run it."
+        - "Each project begins with a working session to surface the decisions you need to make. From there, sprints deliver production ready models, instrumentation, and enablement materials — not slide decks. The same person designs the solution, implements it, and equips your team to run it."
     - title: "What you can expect"
       body:
-        - "Expect transparent plans, weekly momentum, and clear metrics that show progress. Engagements scale from a few focused weeks to multi-quarter partnerships, always with a founder at the table instead of a rotating agency bench."
+        - "Expect transparent plans, weekly momentum, and clear metrics that show progress. Engagements scale from a few focused weeks to multi quarter partnerships, always with a founder at the table instead of a rotating agency bench."
 pillars:
   title: "Three pillars of every engagement"
   items:
-    - title: "Evidence-first decisions"
+    - title: "Evidence first decisions"
       description: "Quantified baselines and measurable targets anchor every recommendation, replacing guesswork with confidence."
     - title: "Momentum through delivery"
       description: "Working software, dashboards, and playbooks ship continuously so your teams can act before the quarter ends."
     - title: "Enablement that sticks"
-      description: "Internal teams leave with training, governance, and documentation that keeps capability in-house after handover."
+      description: "Internal teams leave with training, governance, and documentation that keeps capability in house after handover."
 proof:
   title: "Signals the approach works"
   points:
     - "Dropped fraudulent activity from 10% to 0.6% for a global marketplace while maintaining 97% precision."
     - "Lifted daily revenue by 10% through pricing experimentation for a hospitality group."
-    - "Rolled out ThoughtSpot across enterprise restaurant brands, unlocking self-serve analytics adoption."
+    - "Rolled out ThoughtSpot across enterprise restaurant brands, unlocking self serve analytics adoption."
 founder_quote:
-  quote: "Clients don't need another deck - they need a senior partner who ships the work and leaves the team stronger than they arrived."
+  quote: "Clients don't need another deck — they need a senior partner who ships the work and leaves the team stronger than they arrived."
   name: "Founder, Etterby Analytics"
 cta:
   title: "Ready to build momentum?"

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -6,14 +6,14 @@ services:
     url: "/services/"
 work:
   title: "Selected work"
-  description: "Case studies covering fraud reduction, price optimisation, and analytics enablement for organisations across Cumbria, UK scale-ups, and select global marketplaces."
+  description: "Case studies covering fraud reduction, price optimisation, and analytics enablement for organisations across Cumbria, UK scale ups, and select global marketplaces."
   limit: 2
   view_all:
     label: "Explore all work"
     url: "/work/"
 insights:
   title: "Latest insights"
-  description: "Field-tested playbooks on experimentation, forecasting, and analytics leadership drawn from 11+ years in data roles."
+  description: "Field tested playbooks on experimentation, forecasting, and analytics leadership drawn from 11+ years in data roles."
   limit: 3
   view_all:
     label: "EXPORE ALL INSIGHTS"

--- a/_data/insights_page.yml
+++ b/_data/insights_page.yml
@@ -1,13 +1,13 @@
 hero:
   eyebrow: "Insights"
-  title: "Insights shaped by hands-on delivery"
+  title: "Insights shaped by hands on delivery"
   description:
-    - "Field-tested guidance on experimentation, forecasting, and analytics leadership pulled from shipping platforms, pricing models, and enablement programmes."
-    - "Pragmatic lessons on GA4 tagging, dashboard adoption, and self-service design delivered across restaurants, retail, and SaaS."
+    - "Field tested guidance on experimentation, forecasting, and analytics leadership pulled from shipping platforms, pricing models, and enablement programmes."
+    - "Pragmatic lessons on GA4 tagging, dashboard adoption, and self service design delivered across restaurants, retail, and SaaS."
 categories:
   title: "Topics you can explore"
   items:
-    - name: "Self-service analytics"
+    - name: "Self service analytics"
       detail: "Designing dashboards, narratives, and rituals that keep teams engaged without extra analyst effort."
     - name: "Digital tagging & instrumentation"
       detail: "Making GA4, consent, and event design dependable so marketing and product see the same numbers."

--- a/_data/services_page.yml
+++ b/_data/services_page.yml
@@ -2,9 +2,9 @@ hero:
   eyebrow: "How Etterby Analytics helps"
   title: "Embedded analytics leadership for complex decisions"
   description:
-    - "Etterby Analytics embeds founder-led analytics leadership with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement UK-first companies need to move faster."
+    - "Etterby Analytics embeds founder led analytics leadership with your product, operations, and finance teams to deliver the data foundations, decision science, and enablement UK first companies need to move faster."
     - "On-site sessions across Cumbria pair with remote collaboration for organisations across the UK and select global partners, with engagements scoped around measurable outcomes such as fraud reduction, revenue uplift, or adoption."
-    - "Recent work spans GA4 instrumentation, self-serve dashboard design, and executive storytelling for global restaurant and retail brands."
+    - "Recent work spans GA4 instrumentation, self serve dashboard design, and executive storytelling for global restaurant and retail brands."
 service_models:
   title: "Common engagement patterns"
   items:
@@ -26,7 +26,7 @@ collaboration:
     - "Security, access, and documentation handled in your existing tooling"
 ctas:
   primary:
-    label: "Discuss a project"
+    label: "Contact"
     url: "/contact/"
   secondary:
     label: "See recent work"

--- a/_data/work_page.yml
+++ b/_data/work_page.yml
@@ -8,23 +8,17 @@ filters:
   title: "What Etterby Analytics delivers"
   items:
     - "Data platforms & reliability"
-    - "Decision-ready analytics"
+    - "Decision ready analytics"
     - "Experimentation & forecasting"
     - "Revenue optimisation"
-stats:
-  - label: "Median engagement"
-    value: "12 weeks"
-  - label: "Revenue uplift delivered"
-    value: "+10% daily revenue"
-  - label: "Fraud reduction achieved"
-    value: "10% → 0.6%"
+stats: []
 process:
   title: "A simple, accountable process"
   steps:
     - title: "Frame"
       detail: "Clarify the decision, success metrics, and constraints with stakeholders."
     - title: "Ship"
-      detail: "Deliver production-ready assets with testing, observability, and documentation."
+      detail: "Deliver production ready assets with testing, observability, and documentation."
     - title: "Adopt"
       detail: "Enable teams with playbooks, training, and handover support."
 cta:

--- a/_posts/2025-09-21-clickhouse-vs-postgres.md
+++ b/_posts/2025-09-21-clickhouse-vs-postgres.md
@@ -4,7 +4,7 @@ title: "When ClickHouse shines"
 
 Where columnar OLAP wins for event data and how to roll it out pragmatically.
 
-The decision to introduce ClickHouse at Xcelirate came after months of watching Postgres wheeze under customer events. Analysts needed multi month lookbacks to explain fraud patterns and the row store was not built for that scale. ClickHouse delivered sub-second responses on the same hardware once the team modelled the data around the questions product and risk teams asked every week.
+The decision to introduce ClickHouse at Xcelirate came after months of watching Postgres wheeze under customer events. Analysts needed multi month lookbacks to explain fraud patterns and the row store was not built for that scale. ClickHouse delivered sub second responses on the same hardware once the team modelled the data around the questions product and risk teams asked every week.
 
 It is not a silver bullet though. For transactional workloads and operational updates, Postgres remains the system of record. The winning pattern for Etterby Analytics has been to stream change data capture into ClickHouse, apply dbt for modelling, and keep Postgres for writes and mission critical OLTP. That mirrors how the team rolled out analytics at Vita Mojo where Looker and ThoughtSpot relied on consistent semantics built on top of the warehouse.
 

--- a/_posts/2025-09-21-outcome-first-analytics.md
+++ b/_posts/2025-09-21-outcome-first-analytics.md
@@ -1,5 +1,5 @@
 ---
-title: "Outcome-first analytics"
+title: "Outcome first analytics"
 ---
 
 Prioritise decisions and measurable change over tooling debates. A simple playbook that aligns data work to outcomes.

--- a/_posts/2025-09-22-designing-self-service-dashboards.md
+++ b/_posts/2025-09-22-designing-self-service-dashboards.md
@@ -6,6 +6,6 @@ Wireframes and hero metrics are table stakes. The dashboards that stick pair nar
 
 While leading analytics for Subway franchisees and Vita Mojo operators, Etterby Analytics started every build by interviewing the people opening the dashboard each morning. Their questions shaped the first three tiles, the comparisons, and the alerting rules. Without that context the prettiest layout still sent users back to spreadsheets.
 
-The second ingredient is performance. ThoughtSpot, Power BI, and Hex are only self-serve if they stay sub-second and the data definitions line up with finance. That meant investing as much time in dbt models, caching, and observability as in colours and chart types.
+The second ingredient is performance. ThoughtSpot, Power BI, and Hex are only self serve if they stay sub second and the data definitions line up with finance. That meant investing as much time in dbt models, caching, and observability as in colours and chart types.
 
-Finally the consultancy handed over more than a link. Every launch included release notes, loom walk-throughs, telemetry, and a playbook for how to request tweaks. Adoption is a product, not a deliverable, and treating it like one turns dashboards into decision engines.
+Finally the consultancy handed over more than a link. Every launch included release notes, loom walk throughs, telemetry, and a playbook for how to request tweaks. Adoption is a product, not a deliverable, and treating it like one turns dashboards into decision engines.

--- a/_posts/2025-09-22-ga4-tagging-governance.md
+++ b/_posts/2025-09-22-ga4-tagging-governance.md
@@ -4,8 +4,8 @@ title: "Making GA4 tagging dependable"
 
 The GA4 rush left many teams with brittle instrumentation and consent gaps. Fixing it starts with ownership.
 
-When Etterby Analytics supported a private equity portfolio on its GA4 migration the first win was agreeing who owned each step: agencies handled creative, but measurement planning, QA, and release notes lived with the internal analytics squad. That alignment alone stopped three launch-day outages.
+When Etterby Analytics supported a private equity portfolio on its GA4 migration the first win was agreeing who owned each step: agencies handled creative, but measurement planning, QA, and release notes lived with the internal analytics squad. That alignment alone stopped three launch day outages.
 
-Next came automation. The team wired server-side tagging, wrote dbt tests against the export tables, and hooked up Slack alerts when payloads drifted. Manual spot checks still mattered, but the guardrails caught issues before revenue reporting went sideways.
+Next came automation. The team wired server side tagging, wrote dbt tests against the export tables, and hooked up Slack alerts when payloads drifted. Manual spot checks still mattered, but the guardrails caught issues before revenue reporting went sideways.
 
 Finally the team treated documentation as a product. Every change shipped with measurement diagrams, consent implications, and a rollback plan. It gave marketing the confidence to move fast without sacrificing data quality—or inviting regulators to the party.

--- a/_services/analytics-bi.md
+++ b/_services/analytics-bi.md
@@ -13,12 +13,12 @@ focus:
 **Where each engagement starts**
 - Map critical decisions, data sources, and the definitions that are currently disputed
 - Design a governed semantic layer or ThoughtSpot/BI model that reflects how teams operate
-- Prioritise the dashboards, alerts, and self-serve journeys that matter for revenue and operations
+- Prioritise the dashboards, alerts, and self serve journeys that matter for revenue and operations
 
 **Outcomes**
 - Metric definitions aligned across finance, product, and operations with clear ownership
-- Dashboards and search-driven analytics that load quickly and answer follow-up questions
-- Training cadences that drive adoption and lower reliance on ad-hoc requests
+- Dashboards and search driven analytics that load quickly and answer follow up questions
+- Training cadences that drive adoption and lower reliance on ad hoc requests
 
 **Stack**
 ThoughtSpot, Superset, dbt metrics, Power BI, Hex

--- a/_services/data-platforms-reliability.md
+++ b/_services/data-platforms-reliability.md
@@ -3,7 +3,7 @@ title: "Data Platforms & Reliability"
 position: 1
 tagline: "Modern ELT with dbt, Airflow, and ClickHouse built for scale."
 summary: "Versioned pipelines, observability, and governance that keep metrics trustworthy across teams."
-description: "Design and deliver resilient analytics stacks drawing on founder-led work at Xcelirate, Vita Mojo, and high-growth marketplaces."
+description: "Design and deliver resilient analytics stacks drawing on founder led work at Xcelirate, Vita Mojo, and high growth marketplaces."
 focus:
   - Data Contracts
   - Observability
@@ -18,7 +18,7 @@ focus:
 **Outcomes**
 - Platforms that recover automatically and document themselves
 - Shared visibility into freshness, lineage, and quality for analysts and executives
-- Lower cost-of-change thanks to reusable models and automated deployment
+- Lower cost of change thanks to reusable models and automated deployment
 
 **Stack**
 ClickHouse, dbt, Airflow, Superset, BigQuery, Postgres, Python

--- a/_services/digital-analytics-tagging.md
+++ b/_services/digital-analytics-tagging.md
@@ -2,8 +2,8 @@
 title: "Tagging & Digital Analytics Foundations"
 position: 2
 tagline: "Instrumentation, consent, and GA4 tracking that marketing and product can trust."
-summary: "Stabilise Google Analytics, GTM, and consent journeys so every campaign and funnel report is decision-ready."
-description: "Grounded in founder-led work modernising Vita Mojo's restaurant analytics and advising PE-backed retail brands."
+summary: "Stabilise Google Analytics, GTM, and consent journeys so every campaign and funnel report is decision ready."
+description: "Grounded in founder led work modernising Vita Mojo's restaurant analytics and advising PE backed retail brands."
 focus:
   - GA4 & GTM
   - Consent Governance
@@ -12,13 +12,13 @@ focus:
 
 **Where each engagement starts**
 - Audit GA4 properties, GTM containers, and consent flows against regulatory and commercial requirements
-- Map high-value journeys across web, app, and kiosk to align event naming and parameters with revenue goals
-- Prioritise fixes and net-new instrumentation with an agreed backlog, owners, and implementation plan
+- Map high value journeys across web, app, and kiosk to align event naming and parameters with revenue goals
+- Prioritise fixes and net new instrumentation with an agreed backlog, owners, and implementation plan
 
 **Outcomes**
-- Robust tagging and consent management passing data-loss and privacy reviews
-- Source-of-truth GA4 and BigQuery datasets powering campaign optimisation and product discovery
+- Robust tagging and consent management passing data loss and privacy reviews
+- Source of truth GA4 and BigQuery datasets powering campaign optimisation and product discovery
 - Playbooks that let marketing, product, and agencies launch with confidence and minimal rework
 
 **Stack**
-GA4, GTM, server-side tagging, BigQuery, Looker Studio, dbt
+GA4, GTM, server side tagging, BigQuery, Looker Studio, dbt

--- a/_services/experimentation-forecasting-applied-ml.md
+++ b/_services/experimentation-forecasting-applied-ml.md
@@ -3,7 +3,7 @@ title: "Experimentation, Forecasting & Applied ML"
 position: 5
 tagline: "Practical models and test programmes tied directly to commercial metrics."
 summary: "Frame the decision, design robust experiments or models, and keep them accountable in production."
-description: "From fraud detection to revenue forecasting, every build is anchored in a decade of founder-led decision science delivery."
+description: "From fraud detection to revenue forecasting, every build is anchored in a decade of founder led decision science delivery."
 focus:
   - Experimentation
   - Forecasting
@@ -17,8 +17,8 @@ focus:
 
 **Outcomes**
 - Fraud, pricing, or lifecycle models that reach production with measurable ROI
-- Automated experiment read-outs and forecasting that finance and product can trust
+- Automated experiment read outs and forecasting that finance and product can trust
 - Playbooks for ongoing monitoring, retraining, and stakeholder communication
 
 **Stack**
-Python, scikit-learn, XGBoost, ClickHouse, dbt, Superset, ThoughtSpot
+Python, scikit learn, XGBoost, ClickHouse, dbt, Superset, ThoughtSpot

--- a/_services/revenue-lifecycle-intelligence.md
+++ b/_services/revenue-lifecycle-intelligence.md
@@ -3,7 +3,7 @@ title: "Revenue & Lifecycle Intelligence"
 position: 6
 tagline: "Pricing, retention, and forecasting programmes that influence the P&L."
 summary: "Blend predictive modelling, experimentation, and stakeholder storytelling to unlock revenue and customer lifetime value."
-description: "Battle-tested through price optimisation, lifecycle forecasts, and exec reporting delivered for Xcelirate and global gaming brands."
+description: "Battle tested through price optimisation, lifecycle forecasts, and exec reporting delivered for Xcelirate and global gaming brands."
 focus:
   - Pricing
   - Forecasting
@@ -13,7 +13,7 @@ focus:
 **Where each engagement starts**
 - Understand the revenue motions, lifecycle triggers, and decisions you need to influence
 - Audit historic pricing tests, retention cohorts, and data availability
-- Co-create a roadmap covering modelling, experimentation, and communication milestones
+- Co create a roadmap covering modelling, experimentation, and communication milestones
 
 **Outcomes**
 - Pricing and lifecycle recommendations with measurable impact on revenue and retention

--- a/_services/self-service-dashboards.md
+++ b/_services/self-service-dashboards.md
@@ -1,9 +1,9 @@
 ---
-title: "Self-Service Dashboards & Embedded Analytics"
+title: "Self Service Dashboards & Embedded Analytics"
 position: 4
 tagline: "Design KPI stories and workflows that teams return to every day."
-summary: "Craft ThoughtSpot, Power BI, and Hex experiences that answer follow-up questions and unlock adoption."
-description: "Built from founder-led delivery for Subway franchisees, Vita Mojo operators, and private equity portfolio reviews."
+summary: "Craft ThoughtSpot, Power BI, and Hex experiences that answer follow up questions and unlock adoption."
+description: "Built from founder led delivery for Subway franchisees, Vita Mojo operators, and private equity portfolio reviews."
 focus:
   - Dashboard Design
   - Embedded Workflows
@@ -18,7 +18,7 @@ focus:
 **Outcomes**
 - Executive and operator dashboards that drive weekly and daily rituals across teams
 - Embedded analytics in portals and products with clear ownership, release plans, and usage telemetry
-- Enablement assets that teach teams how to self-serve, explore, and request enhancements effectively
+- Enablement assets that teach teams how to self serve, explore, and request enhancements effectively
 
 **Stack**
 ThoughtSpot, Power BI, Hex, Looker, Superset, Mode

--- a/_work/fraud-detection-eu-classifieds.md
+++ b/_work/fraud-detection-eu-classifieds.md
@@ -9,7 +9,7 @@ duration: "16 weeks"
 position: 1
 featured: true
 summary: "Rebuilt trust & safety analytics and launched fraud models that cut abusive users from 10% to 0.6%."
-description: "Founder-led delivery end-to-end - from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
+description: "Founder led delivery end to end - from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
 results:
   - "Reduced fraudulent users from 10% to 0.6% at 97% precision and 86% detection."
   - "Average detection window improved by 40 days with automated takedown workflows."
@@ -17,7 +17,7 @@ results:
 ---
 
 ### Problem
-Large volumes of short-lived accounts made manual review ineffective. Losses, user trust, and compliance targets were at risk.
+Large volumes of short lived accounts made manual review ineffective. Losses, user trust, and compliance targets were at risk.
 
 ### Solution
 - Data pipeline overhaul (dbt + Airflow + ClickHouse) to unify trust & safety signals

--- a/_work/ga4-tagging-retail-portfolio.md
+++ b/_work/ga4-tagging-retail-portfolio.md
@@ -1,7 +1,7 @@
 ---
 title: "GA4 tagging overhaul for omnichannel retail"
 client: "Private Equity Portfolio"
-industry: "Retail & E-commerce"
+industry: "Retail & E commerce"
 services:
   - Tagging & Digital Analytics Foundations
   - Data Platforms & Reliability
@@ -9,9 +9,9 @@ duration: "8 weeks"
 position: 4
 featured: false
 summary: "Stabilised Google Analytics, consent flows, and campaign attribution across five portfolio brands."
-description: "Founder-led tagging migration and governance playbooks so marketing and product teams could rely on GA4 and BigQuery for decision-making."
+description: "Founder led tagging migration and governance playbooks so marketing and product teams could rely on GA4 and BigQuery for decision making."
 results:
-  - "Unified GTM containers with consent-aware deployment and automated QA."
+  - "Unified GTM containers with consent aware deployment and automated QA."
   - "GA4 to BigQuery export powering merchandising and acquisition dashboards within four weeks."
   - "Runbooks that let agencies launch campaigns without breaking instrumentation."
 ---
@@ -20,11 +20,11 @@ results:
 Disparate GA4 setups, consent tools, and agencies created data loss and conflicting revenue numbers for leadership.
 
 ### Solution
-- Conducted a multi-brand audit covering GA4 schemas, ecommerce events, and CMP integrations
-- Rebuilt measurement plans, implemented enhanced ecommerce tagging, and automated validation with server-side tests
-- Partnered with marketing to embed governance rituals and roll out executive-ready dashboards
+- Conducted a multi brand audit covering GA4 schemas, ecommerce events, and CMP integrations
+- Rebuilt measurement plans, implemented enhanced ecommerce tagging, and automated validation with server side tests
+- Partnered with marketing to embed governance rituals and roll out executive ready dashboards
 
 ### Outcome
 - Trustworthy acquisition and merchandising reporting within one source of truth
-- Faster go-to-market for seasonal campaigns backed by pre-launch QA checklists
+- Faster go to market for seasonal campaigns backed by pre launch QA checklists
 - Internal teams confident managing instrumentation without constant contractor support

--- a/_work/metrics-modernisation-b2b-saas.md
+++ b/_work/metrics-modernisation-b2b-saas.md
@@ -9,11 +9,11 @@ duration: "12 weeks"
 position: 3
 featured: true
 summary: "Delivered a governed metrics layer and ThoughtSpot rollout that aligned revenue and product teams."
-description: "Founder-led delivery across KPI frameworks, modelling, and enablement that standardised reporting for internal teams and enterprise restaurant brands."
+description: "Founder led delivery across KPI frameworks, modelling, and enablement that standardised reporting for internal teams and enterprise restaurant brands."
 results:
   - "Unified metric definitions adopted by finance, sales, and product through governed models."
   - "ThoughtSpot dashboards embedded in client platforms with <2 minute load times for 120+ DAUs."
-  - "Enablement programme that tripled self-serve usage and reduced ad-hoc reporting requests."
+  - "Enablement programme that tripled self serve usage and reduced ad hoc reporting requests."
 ---
 
 ### Problem
@@ -22,9 +22,9 @@ Leadership could not reconcile revenue numbers across systems, slowing strategic
 ### Solution
 - Consolidated event, billing, and CRM data into a governed semantic layer with dbt and ThoughtSpot
 - Delivered executive and operator dashboards with documented SLAs and certified content
-- Ran enablement workshops, office hours, and certification paths to build self-serve confidence
+- Ran enablement workshops, office hours, and certification paths to build self serve confidence
 
 ### Outcome
 - Confident quarterly planning with reconciled revenue metrics and definitions
-- KPI refresh times reduced from hours to minutes with search-driven analytics adoption
-- Cross-functional teams making decisions from the same dashboards and alerts
+- KPI refresh times reduced from hours to minutes with search driven analytics adoption
+- Cross functional teams making decisions from the same dashboards and alerts

--- a/_work/price-optimisation-xcelirate.md
+++ b/_work/price-optimisation-xcelirate.md
@@ -9,7 +9,7 @@ duration: "10 weeks"
 position: 5
 featured: false
 summary: "Delivered dynamic pricing and forecasting models that lifted daily revenue by 10%."
-description: "Founder-led experimentation, predictive modelling, and stakeholder enablement embedded pricing science into commercial planning."
+description: "Founder led experimentation, predictive modelling, and stakeholder enablement embedded pricing science into commercial planning."
 results:
   - "+10% daily revenue uplift within six weeks of launch."
   - "Automated revenue and user forecasts consumed by finance and leadership."
@@ -21,10 +21,10 @@ Pricing decisions relied on manual spreadsheets, producing volatile margins and 
 
 ### Solution
 - Defined the pricing hypotheses, guardrails, and success metrics with product and finance.
-- Built demand elasticity models in Python with dbt-powered feature pipelines feeding Superset dashboards.
+- Built demand elasticity models in Python with dbt powered feature pipelines feeding Superset dashboards.
 - Ran controlled experiments to validate the models before automating weekly recommendations.
 
 ### Outcome
 - Revenue teams received trusted forecasts and recommendations via scheduled reporting and ThoughtSpot search.
 - Marketing and product aligned on a prioritised experimentation roadmap with quantified impact.
-- Leadership gained forward-looking visibility for planning hiring, supply, and promotional spend.
+- Leadership gained forward looking visibility for planning hiring, supply, and promotional spend.

--- a/_work/self-service-dashboards-restaurant-group.md
+++ b/_work/self-service-dashboards-restaurant-group.md
@@ -1,30 +1,30 @@
 ---
-title: "Self-service analytics for global restaurant operators"
+title: "Self service analytics for global restaurant operators"
 client: "Subway & Vita Mojo"
 industry: "Restaurants & Hospitality"
 services:
-  - Self-Service Dashboards & Embedded Analytics
+  - Self Service Dashboards & Embedded Analytics
   - Analytics, BI & Enablement
 duration: "14 weeks"
 position: 2
 featured: true
-summary: "Delivered franchise performance dashboards and enablement that unlocked daily self-serve usage."
-description: "Founder-led partnership with Subway International and Vita Mojo to redesign analytics for franchise owners and operator teams, pairing KPI storytelling with technical delivery."
+summary: "Delivered franchise performance dashboards and enablement that unlocked daily self serve usage."
+description: "Founder led partnership with Subway International and Vita Mojo to redesign analytics for franchise owners and operator teams, pairing KPI storytelling with technical delivery."
 results:
-  - "Franchisee dashboards adopted across 20+ markets with role-based navigation and automated commentary."
+  - "Franchisee dashboards adopted across 20+ markets with role based navigation and automated commentary."
   - "Daily active users tripled as operators relied on guided analyses for staffing, menu, and promotions."
   - "Embedded analytics in the Vita Mojo portal with governance, release notes, and telemetry to steer iterations."
 ---
 
 ### Problem
-Operators were overwhelmed by ad-hoc spreadsheets and slow dashboards, making it difficult to spot underperforming stores and campaign ROI.
+Operators were overwhelmed by ad hoc spreadsheets and slow dashboards, making it difficult to spot underperforming stores and campaign ROI.
 
 ### Solution
 - Interviewed franchisees, marketing, and operations leaders to map critical decisions and reporting rituals
-- Rebuilt KPI definitions in dbt and tuned ThoughtSpot/Power BI models for sub-second exploration
-- Designed story-driven dashboards with usage telemetry, certification workflows, and enablement programmes
+- Rebuilt KPI definitions in dbt and tuned ThoughtSpot/Power BI models for sub second exploration
+- Designed story driven dashboards with usage telemetry, certification workflows, and enablement programmes
 
 ### Outcome
 - Weekly franchise reviews anchored on consistent dashboards and alerts
-- Reduced analyst support tickets as owners self-served diagnostics and exported recommendations
+- Reduced analyst support tickets as owners self served diagnostics and exported recommendations
 - Ongoing roadmap owned by internal teams with the founder advising on quarterly enhancements

--- a/about/index.md
+++ b/about/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About"
-description: "Learn how Etterby Analytics operates, the founder-led principles behind the consultancy, and the outcomes delivered for product and operations teams."
+description: "Learn how Etterby Analytics operates, the founder led principles behind the consultancy, and the outcomes delivered for product and operations teams."
 ---
 {% assign page_content = site.data.about_page %}
 

--- a/contact/index.md
+++ b/contact/index.md
@@ -6,7 +6,7 @@ description: "Start a conversation with Etterby Analytics about analytics, exper
 {% capture contact_intro %}
   <div class="max-w-2xl space-y-3">
     <h1 class="text-3xl md:text-4xl font-semibold">Contact</h1>
-    <p class="opacity-90 text-sm">Carlisle-based sessions are available across Cumbria, with remote support prioritising UK teams while staying open to select global partners.</p>
+    <p class="opacity-90 text-sm">Carlisle based sessions are available across Cumbria, with remote support prioritising UK teams while staying open to select global partners.</p>
   </div>
 {% endcapture %}
 

--- a/index.md
+++ b/index.md
@@ -8,11 +8,10 @@ description: "Reliable pipelines, clear metrics, and practical ML for product an
   <div class="space-y-8">
     <h1 class="text-5xl md:text-6xl font-semibold leading-tight">Analytics that drive outcomes.</h1>
     <p class="text-lg max-w-2xl">
-      Etterby Analytics is a Carlisle-based consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
+      Etterby Analytics is a Carlisle based consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>
     <div class="flex flex-wrap gap-4 items-center">
       <a href="/contact/" class="inline-flex items-center justify-center rounded-full bg-brandblue px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">Contact</a>
-      <a href="/services/" class="text-base font-medium text-brandblack/70 transition hover:text-brandblue focus-visible:underline dark:text-white/70">View services</a>
     </div>
   </div>
 {% endcapture %}

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -8,7 +8,7 @@ description: "How Etterby Analytics handles personal data submitted through the 
     <h1 class="text-3xl font-semibold">Privacy Policy</h1>
     <p class="opacity-90">Etterby Analytics collects personal data only when you submit the contact form or email <a class="underline" href="mailto:hello@etterby.com">hello@etterby.com</a>. Typical fields include your name, work email, company, and project context.</p>
     <p class="opacity-90">The information is used exclusively to respond to your enquiry, qualify the engagement, and maintain a record of conversations. Data is stored securely in email and CRM tooling with access limited to the Etterby Analytics leadership team.</p>
-    <p class="opacity-90">Etterby Analytics does not sell, rent, or share your personal data with third parties. If collaboration requires shared systems (e.g. Slack, project management, analytics platforms) the consultancy will use your company-provided access controls.</p>
+    <p class="opacity-90">Etterby Analytics does not sell, rent, or share your personal data with third parties. If collaboration requires shared systems (e.g. Slack, project management, analytics platforms) the consultancy will use your company provided access controls.</p>
     <p class="opacity-90">You can request updates or deletion of your information at any time by emailing <a class="underline" href="mailto:hello@etterby.com">hello@etterby.com</a>. This policy will evolve as the services and tooling change.</p>
   </div>
 {% endcapture %}

--- a/terms/index.md
+++ b/terms/index.md
@@ -11,7 +11,7 @@ description: "Website terms for Etterby Analytics covering use of content, engag
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Use of content</h2>
-      <p class="opacity-90">All articles, case studies, and materials on this site are provided for general information. They do not constitute professional advice or a guarantee of results. You may reference content for internal, non-commercial purposes provided attribution is retained. Copying or distributing content for commercial gain requires written permission.</p>
+      <p class="opacity-90">All articles, case studies, and materials on this site are provided for general information. They do not constitute professional advice or a guarantee of results. You may reference content for internal, non commercial purposes provided attribution is retained. Copying or distributing content for commercial gain requires written permission.</p>
     </div>
 
     <div class="space-y-3">
@@ -26,7 +26,7 @@ description: "Website terms for Etterby Analytics covering use of content, engag
 
     <div class="space-y-3">
       <h2 class="text-xl font-semibold">Confidentiality & data protection</h2>
-      <p class="opacity-90">Etterby Analytics treats all client materials as confidential and uses them solely for the agreed engagement. Mutual non-disclosure agreements can be executed on request. Personal data is handled in line with the <a class="underline" href="/privacy/">Privacy Policy</a>.</p>
+      <p class="opacity-90">Etterby Analytics treats all client materials as confidential and uses them solely for the agreed engagement. Mutual non disclosure agreements can be executed on request. Personal data is handled in line with the <a class="underline" href="/privacy/">Privacy Policy</a>.</p>
     </div>
 
     <div class="space-y-3">
@@ -35,8 +35,8 @@ description: "Website terms for Etterby Analytics covering use of content, engag
     </div>
 
     <div class="space-y-3">
-      <h2 class="text-xl font-semibold">Third-party links</h2>
-      <p class="opacity-90">Links to external sites are provided for convenience only. Etterby Analytics does not endorse or accept responsibility for third-party content or practices.</p>
+      <h2 class="text-xl font-semibold">Third party links</h2>
+      <p class="opacity-90">Links to external sites are provided for convenience only. Etterby Analytics does not endorse or accept responsibility for third party content or practices.</p>
     </div>
 
     <div class="space-y-3">

--- a/work/index.html
+++ b/work/index.html
@@ -15,14 +15,16 @@ description: "Case studies featuring fraud reduction, revenue optimisation, and 
         <p class="opacity-90">{{ paragraph }}</p>
       {% endfor %}
     </div>
-    <div class="flex flex-wrap gap-3 text-sm">
-      {% for stat in page_content.stats %}
-        <span class="inline-flex items-baseline gap-2 rounded-full bg-white/10 px-4 py-2">
-          <span class="font-semibold text-base tracking-normal">{{ stat.value }}</span>
-          <span class="text-xs uppercase tracking-wide opacity-70">{{ stat.label }}</span>
-        </span>
-      {% endfor %}
-    </div>
+    {% if page_content.stats and page_content.stats.size > 0 %}
+      <div class="flex flex-wrap gap-3 text-sm">
+        {% for stat in page_content.stats %}
+          <span class="inline-flex items-baseline gap-2 rounded-full bg-white/10 px-4 py-2">
+            <span class="font-semibold text-base tracking-normal">{{ stat.value }}</span>
+            <span class="text-xs uppercase tracking-wide opacity-70">{{ stat.label }}</span>
+          </span>
+        {% endfor %}
+      </div>
+    {% endif %}
     <p class="text-sm opacity-80">
       <strong>{{ page_content.filters.title }}:</strong> {{ page_content.filters.items | join: ', ' }}.
       <strong>{{ page_content.process.title }}:</strong> {{ process_titles | join: ' → ' }}.
@@ -70,7 +72,7 @@ description: "Case studies featuring fraud reduction, revenue optimisation, and 
 
 {% if page_content.cta %}
   {% capture work_cta %}
-    <div class="max-w-2xl space-y-4 text-center mx-auto">
+    <div class="max-w-2xl space-y-4 mx-auto">
       <h2 class="text-2xl font-semibold">{{ page_content.cta.title }}</h2>
       <p class="text-sm md:text-base opacity-80">{{ page_content.cta.description }}</p>
       <a href="{{ page_content.cta.url }}" class="inline-flex items-center justify-center rounded-full bg-brandblue px-8 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brandblue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brandblue/40">{{ page_content.cta.label }}</a>


### PR DESCRIPTION
## Summary
- remove the redundant “View services” link from the homepage hero and retain a single Contact CTA
- update services and work page data so CTAs read “Contact” and the work stats pills no longer render
- standardise copy across services, work, and data files to drop hyphenated adjectives per the brief