### PR TITLE
Align work and insights with updated CV narrative

### DIFF
--- a/_posts/2025-09-21-clickhouse-vs-postgres.md
+++ b/_posts/2025-09-21-clickhouse-vs-postgres.md
@@ -2,11 +2,15 @@
 title: "When ClickHouse shines"
 ---
 
-Where columnar OLAP wins for event data and how to roll it out pragmatically.
+### Context
+Etterby Analytics introduced ClickHouse for a global dating marketplace that had stretched Postgres past its limits. Fraud analysts needed multi month lookbacks, operations demanded sub second answers, and nightly exports were masking data quality issues. The columnar store fit the use case once the team aligned the modelling approach with the fraud, pricing, and compliance questions on the roadmap.
 
-The decision to introduce ClickHouse at Xcelirate came after months of watching Postgres wheeze under customer events. Analysts needed multi month lookbacks to explain fraud patterns and the row store was not built for that scale. ClickHouse delivered sub second responses on the same hardware once the team modelled the data around the questions product and risk teams asked every week.
+### Practice
+- Stream change data capture into ClickHouse while keeping Postgres for transactional integrity.
+- Model behavioural features with dbt and orchestrate refreshes through Airflow so investigations and A/B tests referenced the same truth.
+- Pair the rollout with enablement: cheat sheets for materialised views, query templates for analysts, and SLAs agreed with leadership.
 
-It is not a silver bullet though. For transactional workloads and operational updates, Postgres remains the system of record. The winning pattern for Etterby Analytics has been to stream change data capture into ClickHouse, apply dbt for modelling, and keep Postgres for writes and mission critical OLTP. That mirrors how the team rolled out analytics at Vita Mojo where Looker and ThoughtSpot relied on consistent semantics built on top of the warehouse.
-
-Success hinges on enablement. Engineers needed cheat sheets for materialised views, analysts required query templates, and leadership wanted clear SLAs. By pairing the migration with documentation and training, the consultancy made ClickHouse an accelerator rather than a distraction.
+### Takeaways
+- Columnar OLAP delivers value when tied to clear investigative questions, not just curiosity about new tooling.
+- Documentation, training, and observability convert migrations into momentum, mirroring the ThoughtSpot and Superset enablement rolled out for Vita Mojo operators.
 

--- a/_posts/2025-09-21-from-heuristics-to-ml.md
+++ b/_posts/2025-09-21-from-heuristics-to-ml.md
@@ -2,11 +2,16 @@
 title: "From heuristics to ML"
 ---
 
-Shadow evaluation, thresholds, and change management that sticks.
+### Context
+Marketplaces and regulated gaming operators asked Etterby Analytics to modernise rule based fraud controls without risking good customers. Years of heuristics built by operations teams could not scale with attack volumes. The consultancy rebuilt the controls as Python services and ran them alongside the legacy approach to understand gaps.
 
-When marketplaces asked for machine learning to replace the heuristics their operations teams had curated for years, Etterby Analytics pushed for quiet launches first. The team rebuilt the checks as Python services, ran them alongside the legacy rules, and compared every alert. That shadow period exposed blind spots without taking unnecessary risks.
+### Practice
+- Shadow test the machine learning service until precision and recall meet the thresholds agreed with finance, compliance, and trust & safety leaders.
+- Document retraining cadences, rollback paths, and audit trails so regulators and stakeholders can see how decisions are made.
+- Involve frontline reviewers in feature design and override policies, mirroring the collaboration established at The Stars Group and Grosvenor Casinos.
 
-Only once precision and recall cleared the thresholds agreed with finance and compliance did the consultancy recommend a full go live. Documentation, retraining cadences, and rollback paths were written before the switch. Those controls are the reason the fraud programmes led at Xcelirate and The Stars Group hit targets without disrupting good customers.
-
-Technology is the easy part. The harder work is showing frontline teams how their expertise shaped the model and giving them avenues to override with reason. Working sessions, release notes, and a cadence for feedback help the change land. The same playbook translated to deploying experimentation platforms and pricing models across distributed Vita Mojo teams.
+### Takeaways
+- Quiet launches expose blind spots early and build confidence before deprecating heuristics.
+- Governance, change management, and training are the differentiators that kept fraud programmes for the global dating marketplace and online gambling brands on target.
+- The same playbook supports experimentation platforms and pricing models across distributed Vita Mojo teams.
 

--- a/_posts/2025-09-21-outcome-first-analytics.md
+++ b/_posts/2025-09-21-outcome-first-analytics.md
@@ -2,11 +2,15 @@
 title: "Outcome first analytics"
 ---
 
-Prioritise decisions and measurable change over tooling debates. A simple playbook that aligns data work to outcomes.
+### Context
+Prioritise decisions and measurable change over tooling debates. Etterby Analytics anchors every engagement around the commercial metrics that matter this quarter, the guardrails that cannot move, and the accountable owners. That clarity stops scope creep before it starts and keeps analysts from chasing dashboard vanity projects.
 
-Every engagement starts with the same exercise the founder runs with product and operations leaders across Xcelirate, Vita Mojo, and other partners. The team lists the commercial metrics that matter this quarter, the operational guardrails that cannot move, and the people accountable for each. That clarity stops scope creep before it starts and keeps analysts from chasing dashboard vanity projects.
+### Practice
+- Map the smallest analytical delivery that creates feedback: fraud funnel instrumentation and cash exposure forecasting for the global dating marketplace, or executive scorecards to guide Vita Mojo’s product adoption.
+- Set baselines, owners, and iteration plans for each increment so progress is visible week by week.
+- Pair delivery with enablement—shadowing sessions, playbooks, and governance tables—so internal teams can reproduce results without external dependency.
 
-From there Etterby Analytics maps the smallest analytical delivery that creates feedback. At Xcelirate that meant instrumenting fraud funnels and forecasting the exposure in cash terms. At Vita Mojo it was an executive scorecard that made adoption progress visible week by week. Each increment has an owner, a baseline, and a plan to iterate if the first release only gets part of the way.
-
-The last layer is enablement so teams can continue without relying on external support. Shadowing sessions, playbooks, and simple governance tables make sure context is shared and decisions are reproducible. It is the same approach that helped ThoughtSpot adoption stick with enterprise brands and kept finance, product, and operations aligned around the same numbers.
+### Takeaways
+- Framing analytics work around decisions aligns finance, product, and operations without endless steering meetings.
+- Enablement and governance keep improvements alive after the consultancy exits, a lesson reinforced across marketplaces, restaurant groups, and online gaming operators.
 

--- a/_posts/2025-09-22-designing-self-service-dashboards.md
+++ b/_posts/2025-09-22-designing-self-service-dashboards.md
@@ -2,10 +2,15 @@
 title: "Designing dashboards people actually use"
 ---
 
-Wireframes and hero metrics are table stakes. The dashboards that stick pair narrative, diagnostics, and ritual.
+### Context
+Wireframes and hero metrics are table stakes. The dashboards that stick pair narrative, diagnostics, and ritual. Etterby Analytics developed this approach while leading analytics for Subway franchisees and Vita Mojo operators.
 
-While leading analytics for Subway franchisees and Vita Mojo operators, Etterby Analytics started every build by interviewing the people opening the dashboard each morning. Their questions shaped the first three tiles, the comparisons, and the alerting rules. Without that context the prettiest layout still sent users back to spreadsheets.
+### Practice
+- Interview the people opening the dashboard each morning so their questions shape the first tiles, comparisons, and alerting rules.
+- Keep performance and trust high by investing in dbt models, caching, observability, and finance-aligned definitions across ThoughtSpot, Power BI, and Hex.
+- Launch with release notes, walkthroughs, telemetry, and a request playbook so adoption feels like a product, not a deliverable.
 
-The second ingredient is performance. ThoughtSpot, Power BI, and Hex are only self serve if they stay sub second and the data definitions line up with finance. That meant investing as much time in dbt models, caching, and observability as in colours and chart types.
-
-Finally the consultancy handed over more than a link. Every launch included release notes, loom walk throughs, telemetry, and a playbook for how to request tweaks. Adoption is a product, not a deliverable, and treating it like one turns dashboards into decision engines.
+### Takeaways
+- User interviews translate into interfaces that replace spreadsheets rather than add another report.
+- Operational excellence on the data platform side is inseparable from dashboard success.
+- Enablement and feedback loops turn dashboards into decision engines for distributed teams.

--- a/_posts/2025-09-22-ga4-tagging-governance.md
+++ b/_posts/2025-09-22-ga4-tagging-governance.md
@@ -2,10 +2,14 @@
 title: "Making GA4 tagging dependable"
 ---
 
-The GA4 rush left many teams with brittle instrumentation and consent gaps. Fixing it starts with ownership.
+### Context
+The GA4 rush left many teams with brittle instrumentation and consent gaps. Fixing it starts with ownership. Etterby Analytics partnered with a private equity portfolio to stabilise tagging across five brands and align marketing, product, and compliance stakeholders.
 
-When Etterby Analytics supported a private equity portfolio on its GA4 migration the first win was agreeing who owned each step: agencies handled creative, but measurement planning, QA, and release notes lived with the internal analytics squad. That alignment alone stopped three launch day outages.
+### Practice
+- Agree on ownership across agencies and internal teams so measurement planning, QA, and release notes have clear accountability.
+- Automate QA with server side tagging, dbt tests against export tables, and Slack alerts when payloads drift.
+- Treat documentation as a product with measurement diagrams, consent implications, and rollback plans for every release.
 
-Next came automation. The team wired server side tagging, wrote dbt tests against the export tables, and hooked up Slack alerts when payloads drifted. Manual spot checks still mattered, but the guardrails caught issues before revenue reporting went sideways.
-
-Finally the team treated documentation as a product. Every change shipped with measurement diagrams, consent implications, and a rollback plan. It gave marketing the confidence to move fast without sacrificing data quality—or inviting regulators to the party.
+### Takeaways
+- Ownership and automation prevent launch day outages and protect revenue reporting.
+- Transparent playbooks give marketers confidence to move fast without inviting regulatory or reputational risk.

--- a/_services/data-platforms-reliability.md
+++ b/_services/data-platforms-reliability.md
@@ -3,7 +3,7 @@ title: "Data Platforms & Reliability"
 position: 1
 tagline: "Modern ELT with dbt, Airflow, and ClickHouse built for scale."
 summary: "Versioned pipelines, observability, and governance that keep metrics trustworthy across teams."
-description: "Design and deliver resilient analytics stacks drawing on founder led work at Xcelirate, Vita Mojo, and high growth marketplaces."
+description: "Design and deliver resilient analytics stacks drawing on founder led work across global dating platforms, Vita Mojo, and high growth marketplaces."
 focus:
   - Data Contracts
   - Observability

--- a/_services/revenue-lifecycle-intelligence.md
+++ b/_services/revenue-lifecycle-intelligence.md
@@ -3,7 +3,7 @@ title: "Revenue & Lifecycle Intelligence"
 position: 6
 tagline: "Pricing, retention, and forecasting programmes that influence the P&L."
 summary: "Blend predictive modelling, experimentation, and stakeholder storytelling to unlock revenue and customer lifetime value."
-description: "Battle tested through price optimisation, lifecycle forecasts, and exec reporting delivered for Xcelirate and global gaming brands."
+description: "Battle tested through price optimisation, lifecycle forecasts, and exec reporting delivered for global dating marketplaces and regulated gaming brands."
 focus:
   - Pricing
   - Forecasting

--- a/_work/fraud-detection-eu-marketplace.md
+++ b/_work/fraud-detection-eu-marketplace.md
@@ -1,6 +1,6 @@
 ---
-title: "Fraud detection uplift for EU classifieds"
-client: "Marketplace (EU)"
+title: "Fraud detection uplift for European marketplace"
+client: "Dating Marketplace (Europe)"
 industry: "Marketplaces"
 services:
   - Experimentation, Forecasting & Applied ML
@@ -9,7 +9,7 @@ duration: "16 weeks"
 position: 1
 featured: true
 summary: "Rebuilt trust & safety analytics and launched fraud models that cut abusive users from 10% to 0.6%."
-description: "Founder led delivery end to end - from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
+description: "Founder led delivery end to end—from modernising the ClickHouse/dbt stack to deploying Python services with clear governance."
 results:
   - "Reduced fraudulent users from 10% to 0.6% at 97% precision and 86% detection."
   - "Average detection window improved by 40 days with automated takedown workflows."
@@ -23,6 +23,7 @@ Large volumes of short lived accounts made manual review ineffective. Losses, us
 - Data pipeline overhaul (dbt + Airflow + ClickHouse) to unify trust & safety signals
 - Python/Flask microservices with retraining workflow, champion/challenger evaluation, and governance
 - Shadow evaluation, playbooks, and enablement to launch safely across regions
+- Established daily standups with product, security, and leadership to keep scope tight and surface regulatory feedback.
 
 ### Outcome
 - Significant uplift in recall at the target precision alongside clear business guardrails

--- a/_work/price-optimisation-global-marketplace.md
+++ b/_work/price-optimisation-global-marketplace.md
@@ -1,6 +1,6 @@
 ---
 title: "Price optimisation for marketplace growth"
-client: "Xcelirate"
+client: "Global Dating Marketplace"
 industry: "Marketplaces"
 services:
   - Revenue & Lifecycle Intelligence
@@ -23,6 +23,7 @@ Pricing decisions relied on manual spreadsheets, producing volatile margins and 
 - Defined the pricing hypotheses, guardrails, and success metrics with product and finance.
 - Built demand elasticity models in Python with dbt powered feature pipelines feeding Superset dashboards.
 - Ran controlled experiments to validate the models before automating weekly recommendations.
+- Hired and trained analysts to own pricing playbooks, documenting workflows in Confluence for iterative improvements.
 
 ### Outcome
 - Revenue teams received trusted forecasts and recommendations via scheduled reporting and ThoughtSpot search.


### PR DESCRIPTION
## Summary
- replace direct references with global marketplace language across services and case studies
- refresh work case studies with CV-aligned responsibilities, including analyst enablement and leadership rituals
- standardise insight articles with consistent headings, add regulated gaming experience, and tie guidance back to hands-on delivery