### PR TITLE
Remove European marketplace wording from fraud detection case study

### DIFF
--- a/_work/fraud-detection-eu-marketplace.md
+++ b/_work/fraud-detection-eu-marketplace.md
@@ -1,5 +1,5 @@
 ---
-title: "Fraud detection uplift for European marketplace"
+title: "Fraud detection uplift"
 client: "Dating Marketplace (Europe)"
 industry: "Marketplaces"
 services:


### PR DESCRIPTION
## Summary
- shorten the fraud detection work item title by dropping the "European marketplace" suffix
