### PR TITLE
Remove European marketplace reference from dating case study

### DIFF
--- a/_work/fraud-detection-eu-marketplace.md
+++ b/_work/fraud-detection-eu-marketplace.md
@@ -1,6 +1,6 @@
 ---
 title: "Fraud detection uplift"
-client: "Dating Marketplace (Europe)"
+client: "Dating Marketplace"
 industry: "Marketplaces"
 services:
   - Experimentation, Forecasting & Applied ML


### PR DESCRIPTION
## Summary
- update the dating marketplace case study to omit the regional qualifier from the client name
- ensure the selected work section no longer references a European marketplace