### PR TITLE
Update marketing copy to reference marketplaces

### DIFF
--- a/_posts/2025-09-21-clickhouse-vs-postgres.md
+++ b/_posts/2025-09-21-clickhouse-vs-postgres.md
@@ -3,7 +3,7 @@ title: "When ClickHouse shines"
 ---
 
 ### Context
-Etterby Analytics introduced ClickHouse for a global dating marketplace that had stretched Postgres past its limits. Fraud analysts needed multi month lookbacks, operations demanded sub second answers, and nightly exports were masking data quality issues. The columnar store fit the use case once the team aligned the modelling approach with the fraud, pricing, and compliance questions on the roadmap.
+Etterby Analytics introduced ClickHouse for a global marketplace that had stretched Postgres past its limits. Fraud analysts needed multi month lookbacks, operations demanded sub second answers, and nightly exports were masking data quality issues. The columnar store fit the use case once the team aligned the modelling approach with the fraud, pricing, and compliance questions on the roadmap.
 
 ### Practice
 - Stream change data capture into ClickHouse while keeping Postgres for transactional integrity.

--- a/_posts/2025-09-21-from-heuristics-to-ml.md
+++ b/_posts/2025-09-21-from-heuristics-to-ml.md
@@ -12,6 +12,6 @@ Marketplaces and regulated gaming operators asked Etterby Analytics to modernise
 
 ### Takeaways
 - Quiet launches expose blind spots early and build confidence before deprecating heuristics.
-- Governance, change management, and training are the differentiators that kept fraud programmes for the global dating marketplace and online gambling brands on target.
+- Governance, change management, and training are the differentiators that kept fraud programmes for global marketplaces and online gambling brands on target.
 - The same playbook supports experimentation platforms and pricing models across distributed Vita Mojo teams.
 

--- a/_posts/2025-09-21-outcome-first-analytics.md
+++ b/_posts/2025-09-21-outcome-first-analytics.md
@@ -6,7 +6,7 @@ title: "Outcome first analytics"
 Prioritise decisions and measurable change over tooling debates. Etterby Analytics anchors every engagement around the commercial metrics that matter this quarter, the guardrails that cannot move, and the accountable owners. That clarity stops scope creep before it starts and keeps analysts from chasing dashboard vanity projects.
 
 ### Practice
-- Map the smallest analytical delivery that creates feedback: fraud funnel instrumentation and cash exposure forecasting for the global dating marketplace, or executive scorecards to guide Vita Mojo’s product adoption.
+- Map the smallest analytical delivery that creates feedback: fraud funnel instrumentation and cash exposure forecasting for the global marketplace, or executive scorecards to guide Vita Mojo’s product adoption.
 - Set baselines, owners, and iteration plans for each increment so progress is visible week by week.
 - Pair delivery with enablement—shadowing sessions, playbooks, and governance tables—so internal teams can reproduce results without external dependency.
 

--- a/_services/data-platforms-reliability.md
+++ b/_services/data-platforms-reliability.md
@@ -3,7 +3,7 @@ title: "Data Platforms & Reliability"
 position: 1
 tagline: "Modern ELT with dbt, Airflow, and ClickHouse built for scale."
 summary: "Versioned pipelines, observability, and governance that keep metrics trustworthy across teams."
-description: "Design and deliver resilient analytics stacks drawing on founder led work across global dating platforms, Vita Mojo, and high growth marketplaces."
+description: "Design and deliver resilient analytics stacks drawing on founder led work across global marketplaces, Vita Mojo, and other high growth platforms."
 focus:
   - Data Contracts
   - Observability

--- a/_services/revenue-lifecycle-intelligence.md
+++ b/_services/revenue-lifecycle-intelligence.md
@@ -3,7 +3,7 @@ title: "Revenue & Lifecycle Intelligence"
 position: 6
 tagline: "Pricing, retention, and forecasting programmes that influence the P&L."
 summary: "Blend predictive modelling, experimentation, and stakeholder storytelling to unlock revenue and customer lifetime value."
-description: "Battle tested through price optimisation, lifecycle forecasts, and exec reporting delivered for global dating marketplaces and regulated gaming brands."
+description: "Battle tested through price optimisation, lifecycle forecasts, and exec reporting delivered for global marketplaces and regulated gaming brands."
 focus:
   - Pricing
   - Forecasting


### PR DESCRIPTION
## Summary
- replace references to marketplaces with general marketplace language across posts and service pages
- keep service descriptions consistent with the broader marketplace positioning