### PR TITLE
Update default site title branding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 
-title: "Etterby Analytics"
+title: "Etterby Analytics | Data Consulting"
 description: "Premium, minimal, outcomes first analytics consulting. Pipelines, metrics, and ML that ship and stick."
 url: "https://etterby.com"  # set to https://etterby.com when live
 baseurl: ""  # set to /analytics only if using subpath


### PR DESCRIPTION
## Summary
- Update the site-wide title to "Etterby Analytics | Data Consulting" so search results display the full brand message instead of an em dash prefix.