### PR TITLE
Fix homepage title branding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 
-title: "Etterby Analytics"
+title: "Etterby Analytics | Data Consulting"
 description: "Premium, minimal, outcomes first analytics consulting. Pipelines, metrics, and ML that ship and stick."
 url: "https://etterby.com"  # set to https://etterby.com when live
 baseurl: ""  # set to /analytics only if using subpath

--- a/index.md
+++ b/index.md
@@ -1,12 +1,13 @@
 ---
 layout: default
-title: "Analytics that drive outcomes"
+title: "Etterby Analytics | Data Consulting"
+hero_title: "Analytics that drive outcomes."
 description: "Reliable pipelines, clear metrics, and practical ML for product and operations teams."
 ---
 {% assign home = site.data.home %}
 {% capture hero_block %}
   <div class="space-y-8">
-    <h1 class="text-5xl md:text-6xl font-semibold leading-tight">Analytics that drive outcomes.</h1>
+    <h1 class="text-5xl md:text-6xl font-semibold leading-tight">{{ page.hero_title | default: 'Analytics that drive outcomes.' }}</h1>
     <p class="text-lg max-w-2xl">
       Etterby Analytics is a Carlisle based consultancy that helps product and operations teams across Cumbria, throughout the UK, and select global partners ship reliable data pipelines, clear metrics, and practical ML – without drama.
     </p>


### PR DESCRIPTION
## Summary
- Set the homepage front matter title to the full brand string so the `<title>` tag renders without a dangling separator when search engines rewrite it.
- Move the homepage hero heading into front matter so the page retains its tagline while using the updated title metadata.